### PR TITLE
🔧 Add metrics for GitHub generation routes

### DIFF
--- a/app/api/generate-github-design/route.ts
+++ b/app/api/generate-github-design/route.ts
@@ -8,6 +8,14 @@ import { db } from "@/lib/prisma";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { invokeGeminiWithFallback } from "@/app/(protected)/generate/utils/aiClient";
 import { getUserApiKeys } from "@/lib/api-keys/getUserApiKeys";
+import {
+  aiGenerationRequestsTotal,
+  aiGenerationSuccessTotal,
+  aiGenerationFailureTotal,
+  aiGenerationDurationSeconds,
+  httpRequestsTotal,
+  databaseQueryDurationSeconds,
+} from "@/lib/metrics";
 
 interface GenerateGithubDesignRequest {
   owner: string;
@@ -16,6 +24,9 @@ interface GenerateGithubDesignRequest {
 }
 
 export async function POST(request: NextRequest) {
+  const route = "/api/generate-github-design";
+  const method = "POST";
+
   try {
     // Check authentication
     const session = await getServerSession(authOptions);
@@ -23,6 +34,7 @@ export async function POST(request: NextRequest) {
     const userId = session?.user?.id;
 
     if (!userId) {
+      httpRequestsTotal.inc({ route, method, status_code: "401" });
       return NextResponse.json(
         { success: false, error: "Unauthorized" },
         { status: 401 },
@@ -33,6 +45,7 @@ export async function POST(request: NextRequest) {
     const { owner, repo, analysisData } = body;
 
     if (!owner || !repo || !analysisData) {
+      httpRequestsTotal.inc({ route, method, status_code: "400" });
       return NextResponse.json(
         {
           success: false,
@@ -44,6 +57,7 @@ export async function POST(request: NextRequest) {
 
     // Check if a design already exists for this repository
     const repoIdentifier = `${repo}`;
+    const dbFindStart = Date.now();
     const existingGeneration = await db.generation.findFirst({
       where: {
         userId: userId,
@@ -56,9 +70,14 @@ export async function POST(request: NextRequest) {
         createdAt: "desc", // Get the most recent one
       },
     });
+    databaseQueryDurationSeconds.observe(
+      { operation: "findFirst" },
+      (Date.now() - dbFindStart) / 1000,
+    );
 
     // If design already exists, return it from cache
     if (existingGeneration?.githubGeneration) {
+      httpRequestsTotal.inc({ route, method, status_code: "200" });
       return NextResponse.json({
         success: true,
         generationId: existingGeneration.id,
@@ -83,10 +102,19 @@ export async function POST(request: NextRequest) {
     // 🔑 Fetch user's API keys
     const userApiKeys = await getUserApiKeys(userId);
 
+    aiGenerationRequestsTotal.inc();
+    const aiStart = Date.now();
     const { response } = await invokeGeminiWithFallback(
       messages,
       userApiKeys.geminiApiKey,
     );
+    const aiDuration = (Date.now() - aiStart) / 1000;
+    aiGenerationDurationSeconds.observe(aiDuration);
+
+    if (!response || !response.content) {
+      aiGenerationFailureTotal.inc();
+      throw new Error("Empty AI response received.");
+    }
     let mermaidDiagram = response.content as string;
 
     // Clean up the response - remove markdown code blocks if present
@@ -96,6 +124,7 @@ export async function POST(request: NextRequest) {
       .trim();
 
     // Save to database
+    const dbCreateStart = Date.now();
     const generation = await db.generation.create({
       data: {
         userInput: repoIdentifier,
@@ -103,7 +132,14 @@ export async function POST(request: NextRequest) {
         userId: userId,
       },
     });
+    databaseQueryDurationSeconds.observe(
+      { operation: "create" },
+      (Date.now() - dbCreateStart) / 1000,
+    );
 
+    aiGenerationSuccessTotal.inc();
+
+    httpRequestsTotal.inc({ route, method, status_code: "200" });
     return NextResponse.json({
       success: true,
       generationId: generation.id,
@@ -111,7 +147,9 @@ export async function POST(request: NextRequest) {
       cached: false, // Indicate this is newly generated
     });
   } catch (error) {
+    aiGenerationFailureTotal.inc();
     console.error("GitHub design generation error:", error);
+    httpRequestsTotal.inc({ route, method, status_code: "500" });
     return NextResponse.json(
       {
         success: false,

--- a/app/api/generate-github-design/route.ts
+++ b/app/api/generate-github-design/route.ts
@@ -26,6 +26,8 @@ interface GenerateGithubDesignRequest {
 export async function POST(request: NextRequest) {
   const route = "/api/generate-github-design";
   const method = "POST";
+  let aiRequested = false;
+  let aiFailureRecorded = false;
 
   try {
     // Check authentication
@@ -103,6 +105,7 @@ export async function POST(request: NextRequest) {
     const userApiKeys = await getUserApiKeys(userId);
 
     aiGenerationRequestsTotal.inc();
+    aiRequested = true;
     const aiStart = Date.now();
     const { response } = await invokeGeminiWithFallback(
       messages,
@@ -113,6 +116,7 @@ export async function POST(request: NextRequest) {
 
     if (!response || !response.content) {
       aiGenerationFailureTotal.inc();
+      aiFailureRecorded = true;
       throw new Error("Empty AI response received.");
     }
     let mermaidDiagram = response.content as string;
@@ -147,7 +151,9 @@ export async function POST(request: NextRequest) {
       cached: false, // Indicate this is newly generated
     });
   } catch (error) {
-    aiGenerationFailureTotal.inc();
+    if (aiRequested && !aiFailureRecorded) {
+      aiGenerationFailureTotal.inc();
+    }
     console.error("GitHub design generation error:", error);
     httpRequestsTotal.inc({ route, method, status_code: "500" });
     return NextResponse.json(

--- a/app/api/github-generation/[id]/improve-diagram/route.ts
+++ b/app/api/github-generation/[id]/improve-diagram/route.ts
@@ -4,8 +4,17 @@ import {
   GITHUB_AI_SUGGEST_PROMPT,
   GITHUB_AI_CUSTOM_PROMPT_TEMPLATE,
 } from "@/lib/prompts/githubAISuggestPrompt";
+import {
+  aiGenerationRequestsTotal,
+  aiGenerationSuccessTotal,
+  aiGenerationFailureTotal,
+  aiGenerationDurationSeconds,
+} from "@/lib/metrics";
 
 export async function POST(req: NextRequest) {
+  let aiRequested = false;
+  let aiFailureRecorded = false;
+
   try {
     const { currentDiagram, userPrompt, useAISuggestion } = await req.json();
 
@@ -39,7 +48,19 @@ export async function POST(req: NextRequest) {
     }
 
     // Call OpenAI
+    aiGenerationRequestsTotal.inc();
+    aiRequested = true;
+    const aiStart = Date.now();
     const response = await openAiLLM.invoke(prompt);
+    const aiDuration = (Date.now() - aiStart) / 1000;
+    aiGenerationDurationSeconds.observe(aiDuration);
+
+    if (!response || !response.content) {
+      aiGenerationFailureTotal.inc();
+      aiFailureRecorded = true;
+      throw new Error("Empty AI response received.");
+    }
+
     const improvedDiagram = response.content as string;
 
     // Clean up the response (remove markdown code blocks if present)
@@ -48,11 +69,15 @@ export async function POST(req: NextRequest) {
       .replace(/```\n?/g, "")
       .trim();
 
+    aiGenerationSuccessTotal.inc();
     return NextResponse.json({
       success: true,
       improvedDiagram: cleanedDiagram,
     });
   } catch (error) {
+    if (aiRequested && !aiFailureRecorded) {
+      aiGenerationFailureTotal.inc();
+    }
     console.error("Error improving diagram:", error);
     return NextResponse.json(
       {

--- a/app/api/github-generation/[id]/improve-diagram/route.ts
+++ b/app/api/github-generation/[id]/improve-diagram/route.ts
@@ -9,9 +9,12 @@ import {
   aiGenerationSuccessTotal,
   aiGenerationFailureTotal,
   aiGenerationDurationSeconds,
+  httpRequestsTotal,
 } from "@/lib/metrics";
 
 export async function POST(req: NextRequest) {
+  const route = "/api/github-generation/[id]/improve-diagram";
+  const method = "POST";
   let aiRequested = false;
   let aiFailureRecorded = false;
 
@@ -19,6 +22,7 @@ export async function POST(req: NextRequest) {
     const { currentDiagram, userPrompt, useAISuggestion } = await req.json();
 
     if (!currentDiagram) {
+      httpRequestsTotal.inc({ route, method, status_code: "400" });
       return NextResponse.json(
         { success: false, error: "Current diagram is required" },
         { status: 400 },
@@ -36,6 +40,7 @@ export async function POST(req: NextRequest) {
     } else {
       // Use custom user prompt
       if (!userPrompt || userPrompt.trim() === "") {
+        httpRequestsTotal.inc({ route, method, status_code: "400" });
         return NextResponse.json(
           { success: false, error: "User prompt is required" },
           { status: 400 },
@@ -70,6 +75,7 @@ export async function POST(req: NextRequest) {
       .trim();
 
     aiGenerationSuccessTotal.inc();
+    httpRequestsTotal.inc({ route, method, status_code: "200" });
     return NextResponse.json({
       success: true,
       improvedDiagram: cleanedDiagram,
@@ -79,6 +85,7 @@ export async function POST(req: NextRequest) {
       aiGenerationFailureTotal.inc();
     }
     console.error("Error improving diagram:", error);
+    httpRequestsTotal.inc({ route, method, status_code: "500" });
     return NextResponse.json(
       {
         success: false,


### PR DESCRIPTION
## Description

Add Prometheus instrumentation to GitHub design generation and diagram improvement endpoints to align with the main generation route. This includes AI request/success/failure counts, AI duration timing, DB query timing, and normalized `http_requests_total` status_code labels.

## Related Issue

#95 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## How Has This Been Tested?

- `corepack pnpm lint` (warnings only; no errors)
- Manual API calls:
  - `POST /api/github-generation/:id/improve-diagram` returned 500 due to missing `OPENAI_API_KEY`; AI failure metrics incremented as expected.
  - `POST /api/generate-github-design` returned 500 due to missing `GEMINI_API_KEY` at module init; handler did not execute, so route metrics did not increment.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published