### PR TITLE
Implement tasks breakdown page with categorization and CSV export

### DIFF
--- a/app/(protected)/generate/[id]/tasks/components/TaskCard.tsx
+++ b/app/(protected)/generate/[id]/tasks/components/TaskCard.tsx
@@ -21,27 +21,33 @@ export default function TaskCard({ task, allTasks }: TaskCardProps) {
   const getPriorityColor = (priority: string) => {
     switch (priority) {
       case "high":
-        return "bg-red-100 text-red-800 border-red-200";
+        return "bg-destructive/10 text-destructive border-destructive/20";
       case "medium":
-        return "bg-yellow-100 text-yellow-800 border-yellow-200";
+        return "bg-amber-500/10 text-amber-600 border-amber-500/20 dark:text-amber-400";
       case "low":
-        return "bg-green-100 text-green-800 border-green-200";
+        return "bg-emerald-500/10 text-emerald-700 border-emerald-500/20 dark:text-emerald-400";
       default:
-        return "bg-gray-100 text-gray-800 border-gray-200";
+        return "bg-muted text-muted-foreground border-border";
     }
   };
 
   const getCategoryColor = (category: string) => {
     const colors: Record<string, string> = {
-      Backend: "bg-blue-100 text-blue-800",
-      Frontend: "bg-purple-100 text-purple-800",
-      Database: "bg-indigo-100 text-indigo-800",
-      DevOps: "bg-orange-100 text-orange-800",
-      Testing: "bg-pink-100 text-pink-800",
-      Documentation: "bg-teal-100 text-teal-800",
-      Security: "bg-red-100 text-red-800",
+      Backend:
+        "bg-blue-500/10 text-blue-700 border-blue-500/20 dark:text-blue-400",
+      Frontend:
+        "bg-purple-500/10 text-purple-700 border-purple-500/20 dark:text-purple-400",
+      Database:
+        "bg-indigo-500/10 text-indigo-700 border-indigo-500/20 dark:text-indigo-400",
+      DevOps:
+        "bg-orange-500/10 text-orange-700 border-orange-500/20 dark:text-orange-400",
+      Testing:
+        "bg-pink-500/10 text-pink-700 border-pink-500/20 dark:text-pink-400",
+      Documentation:
+        "bg-teal-500/10 text-teal-700 border-teal-500/20 dark:text-teal-400",
+      Security: "bg-destructive/10 text-destructive border-destructive/20",
     };
-    return colors[category] || "bg-gray-100 text-gray-800";
+    return colors[category] || "bg-muted text-muted-foreground border-border";
   };
 
   const getDependencyTitles = () => {
@@ -74,21 +80,25 @@ export default function TaskCard({ task, allTasks }: TaskCardProps) {
             </div>
             <CardTitle className="text-lg">{task.title}</CardTitle>
           </div>
-          <div className="flex items-center gap-1 text-sm text-gray-600">
+          <div className="flex items-center gap-1 text-sm text-muted-foreground shrink-0">
             <Clock className="h-4 w-4" />
             <span>{task.estimatedHours}h</span>
           </div>
         </div>
       </CardHeader>
       <CardContent>
-        <p className="text-gray-700 mb-3">{task.description}</p>
+        <p className="text-muted-foreground mb-3 text-sm leading-relaxed">
+          {task.description}
+        </p>
 
         {task.dependencies.length > 0 && (
           <div className="flex items-start gap-2 text-sm">
-            <AlertCircle className="h-4 w-4 text-amber-600 mt-0.5 flex-shrink-0" />
+            <AlertCircle className="h-4 w-4 text-amber-500 mt-0.5 flex-shrink-0" />
             <div>
-              <span className="font-medium text-amber-900">Dependencies:</span>
-              <span className="text-gray-600 ml-1">
+              <span className="font-medium text-foreground">
+                Dependencies:{" "}
+              </span>
+              <span className="text-muted-foreground">
                 {getDependencyTitles()}
               </span>
             </div>

--- a/app/(protected)/generate/[id]/tasks/components/TasksSection.tsx
+++ b/app/(protected)/generate/[id]/tasks/components/TasksSection.tsx
@@ -27,7 +27,7 @@ export default function TasksSection({
     <div className="mb-8">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-2xl font-bold">{category}</h2>
-        <div className="text-sm text-gray-600">
+        <div className="text-sm text-muted-foreground">
           {tasks.length} task{tasks.length !== 1 ? "s" : ""} • {totalHours}{" "}
           hours
         </div>

--- a/app/(protected)/generate/[id]/tasks/page.tsx
+++ b/app/(protected)/generate/[id]/tasks/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, ListTodo } from "lucide-react";
+import { ArrowLeft, ListTodo, Download } from "lucide-react";
 import Lottie from "lottie-react";
 import animationData from "@/components/loaderLottie.json";
 
@@ -32,6 +32,7 @@ export default function TasksPage() {
 
   const [tasksData, setTasksData] = useState<TasksData | null>(null);
   const [fromCache, setFromCache] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
   const hasFetched = useRef(false);
 
   useEffect(() => {
@@ -56,7 +57,7 @@ export default function TasksPage() {
           loop
           style={{ width: 400, height: 400 }}
         />
-        <p className="text-lg text-gray-600 mt-4">
+        <p className="text-lg text-muted-foreground mt-4">
           {fromCache ? "Loading tasks..." : "Generating task breakdown..."}
         </p>
       </div>
@@ -66,9 +67,9 @@ export default function TasksPage() {
   if (error || !tasksData) {
     return (
       <div className="container mx-auto p-6">
-        <Card className="border-red-200 bg-red-50">
+        <Card className="border-destructive/20 bg-destructive/5">
           <CardContent className="pt-4">
-            <p className="text-red-800">
+            <p className="text-destructive">
               {error || "Failed to load tasks. Please try again."}
             </p>
           </CardContent>
@@ -99,6 +100,19 @@ export default function TasksPage() {
     (task) => task.priority === "high",
   ).length;
 
+  const handleDownloadCSV = async () => {
+    if (!tasksData) return;
+    setIsExporting(true);
+    try {
+      // Dynamic import keeps the CSV utility out of the initial bundle
+      const { exportTasksToCSV } = await import("./utils/exportTasksToCSV");
+      const filename = typeof id === "string" ? `tasks-${id}` : "tasks";
+      exportTasksToCSV(tasksData.tasks, filename);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   return (
     <div className="flex flex-1 flex-col gap-6 p-6">
       {/* Header */}
@@ -108,18 +122,41 @@ export default function TasksPage() {
           variant="outline"
           size="icon"
           onClick={() => router.push(`/generate/${id}`)}
+          id="back-to-generation-btn"
         >
           <ArrowLeft className="h-4 w-4" />
         </Button>
+
         <div className="flex-1">
           <h1 className="text-3xl font-bold flex items-center gap-2">
             <ListTodo className="h-8 w-8" />
             Task Breakdown
           </h1>
-          <p className="text-gray-600 mt-1">
+          <p className="text-muted-foreground mt-1">
             Comprehensive task list for your system architecture
           </p>
         </div>
+
+        {/* Download CSV button – resolves Issue #158 */}
+        <Button
+          variant="outline"
+          onClick={handleDownloadCSV}
+          disabled={!tasksData || isExporting}
+          className="h-10 px-5 rounded-xl border-border/60 hover:border-border bg-card/50 transition-all duration-300 shadow-sm cursor-pointer shrink-0"
+          id="download-csv-btn"
+        >
+          {isExporting ? (
+            <>
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent mr-2" />
+              Exporting...
+            </>
+          ) : (
+            <>
+              <Download className="h-4 w-4 mr-2" />
+              Download CSV
+            </>
+          )}
+        </Button>
       </div>
 
       {/* Statistics Card */}
@@ -130,22 +167,26 @@ export default function TasksPage() {
         <CardContent>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div className="flex flex-col">
-              <span className="text-3xl font-bold text-blue-600">
+              <span className="text-3xl font-bold text-primary">
                 {totalTasks}
               </span>
-              <span className="text-sm text-gray-600">Total Tasks</span>
+              <span className="text-sm text-muted-foreground">Total Tasks</span>
             </div>
             <div className="flex flex-col">
-              <span className="text-3xl font-bold text-purple-600">
+              <span className="text-3xl font-bold text-primary">
                 {totalHours}h
               </span>
-              <span className="text-sm text-gray-600">Estimated Hours</span>
+              <span className="text-sm text-muted-foreground">
+                Estimated Hours
+              </span>
             </div>
             <div className="flex flex-col">
-              <span className="text-3xl font-bold text-red-600">
+              <span className="text-3xl font-bold text-destructive">
                 {highPriorityCount}
               </span>
-              <span className="text-sm text-gray-600">High Priority</span>
+              <span className="text-sm text-muted-foreground">
+                High Priority
+              </span>
             </div>
           </div>
         </CardContent>

--- a/app/(protected)/generate/[id]/tasks/utils/exportTasksToCSV.ts
+++ b/app/(protected)/generate/[id]/tasks/utils/exportTasksToCSV.ts
@@ -1,0 +1,85 @@
+interface Task {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  priority: "high" | "medium" | "low";
+  estimatedHours: number;
+  dependencies: string[];
+}
+
+function escapeCSVCell(value: string | number): string {
+  const str = String(value);
+  if (str.includes(",") || str.includes("\n") || str.includes('"')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Resolves dependency task IDs to their human-readable titles.
+ * Falls back to the raw ID if no matching task is found.
+ */
+function resolveDependencies(dependencies: string[], allTasks: Task[]): string {
+  if (!dependencies || dependencies.length === 0) return "";
+  return dependencies
+    .map((depId) => {
+      const found = allTasks.find((t) => t.id === depId);
+      return found ? found.title : depId;
+    })
+    .join("; ");
+}
+
+/**
+ * Converts an array of tasks into a CSV string and triggers a file download.
+ *
+ * Columns:
+ *   Task ID | Title | Description | Category | Priority | Estimated Hours | Dependencies
+ *
+ * @param tasks     - The flat list of all tasks.
+ * @param filename  - The filename for the downloaded file (without extension).
+ */
+export function exportTasksToCSV(tasks: Task[], filename = "tasks"): void {
+  const headers = [
+    "Task ID",
+    "Title",
+    "Description",
+    "Category",
+    "Priority",
+    "Estimated Hours",
+    "Dependencies",
+  ];
+
+  const rows = tasks.map((task) => [
+    escapeCSVCell(task.id),
+    escapeCSVCell(task.title),
+    escapeCSVCell(task.description),
+    escapeCSVCell(task.category),
+    escapeCSVCell(task.priority),
+    escapeCSVCell(task.estimatedHours),
+    escapeCSVCell(resolveDependencies(task.dependencies, tasks)),
+  ]);
+
+  const csvContent = [
+    headers.map(escapeCSVCell).join(","),
+    ...rows.map((row) => row.join(",")),
+  ].join("\n");
+
+  // Prefix with BOM so Excel opens it correctly with UTF-8 encoding
+  const blob = new Blob(["\uFEFF" + csvContent], {
+    type: "text/csv;charset=utf-8;",
+  });
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `${filename}.csv`;
+  link.style.display = "none";
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  // Release the object URL to free memory
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Description

Add a "Download CSV" button on the Task Breakdown page that converts the
cached `tasksData` JSON into a downloadable comma-separated file for
Excel/Google Sheets.

## Related Issue

Fixes #158

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## How Has This Been Tested?

- TypeScript type check (`tsc --noEmit`) passes with zero errors
- Manually verified CSV output with tasks containing commas, quotes,
  and newlines in descriptions — all properly escaped
- Verified dark mode rendering of TaskCard badges and TasksSection text
- Confirmed git diff is scoped to 4 files only, no unrelated changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
