### PR TITLE
fix: restrict /api/metrics endpoint to authenticated admin users only

### DIFF
--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,8 +1,20 @@
 import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { register } from "@/lib/metrics";
 
 export async function GET() {
   try {
+    const session = await getServerSession(authOptions);
+    const adminEmails = process.env.ADMIN_EMAIL?.split(",") ?? [];
+
+    if (
+      !session?.user?.email ||
+      !adminEmails.includes(session.user.email)
+    ) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     const metrics = await register.metrics();
     return new NextResponse(metrics, {
       headers: {


### PR DESCRIPTION
## What this fixes
Closes #194

## Description
The /api/metrics endpoint was publicly accessible with zero 
authentication, exposing sensitive internal data including 
user IDs, generation counts, activity timestamps, HTTP error 
rates, and database query timings to anyone on the internet.

## Changes made
`app/api/metrics/route.ts`

- Added `getServerSession` import from `next-auth`
- Added `authOptions` import from the NextAuth route  
- Added auth guard that checks the caller has a valid session 
  and their email is in the `ADMIN_EMAIL` environment variable
- Returns HTTP 403 Forbidden if not authenticated or not admin

## Type
- [x] Bug fix / Security fix

## Suggested Labels
`level-1` `security` `backend`