### PR TITLE
fix: apply rate limiting to forgot-password endpoint to prevent email bombing

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/prisma";
 import crypto from "crypto";
 import { sendMail } from "@/lib/mailer";
 import { forgotPasswordEmailTemplate } from "@/components/email-template/forgotPasswordEmailTemplate";
+import { loginRateLimitIP } from "@/lib/rateLimit";
 import {
   httpRequestsTotal,
   httpRequestDurationSeconds,
@@ -28,6 +29,20 @@ export async function POST(req: Request) {
       return NextResponse.json(
         { message: "Email is required" },
         { status: 400 },
+      );
+    }
+
+    const ip = req.headers.get("x-forwarded-for") ?? "unknown";
+    const { success } = await loginRateLimitIP.limit(`forgot:${ip}`);
+    if (!success) {
+      apiGatewayErrorsTotal.inc({ status_code: "429" });
+      httpRequestDurationSeconds.observe(
+        { route },
+        (Date.now() - startTime) / 1000,
+      );
+      return NextResponse.json(
+        { message: "Too many requests. Please try again later." },
+        { status: 429 },
       );
     }
 


### PR DESCRIPTION
## What this fixes
Closes #196

## Description
The /api/auth/forgot-password endpoint had no rate limiting,
allowing an attacker to spam unlimited password reset emails 
to any user's inbox and exhaust the Google SMTP quota.

## Changes made
`app/api/auth/forgot-password/route.ts`

- Added `loginRateLimitIP` import from `@/lib/rateLimit`
- Added rate limit check after email validation but before 
  DB lookup using `forgot:${ip}` as key
- Allows 5 requests per IP per minute
- Returns HTTP 429 if limit exceeded with metrics tracking

## Notes
`loginRateLimitIP` already existed in `lib/rateLimit.ts` — 
this fix purely reuses the existing limiter. No new 
dependencies added.

## Type
- [x] Bug fix / Security fix

## Suggested Labels
`level-1` `security` `backend`