### PR TITLE
fix: return correct HTTP 400 status on reset-password validation errors

### DIFF
--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -77,10 +77,10 @@ export async function POST(req: Request) {
         { route },
         (Date.now() - startTime) / 1000,
       );
-      return NextResponse.json({
-        status: 400,
-        message: "Token and password are required",
-      });
+      return NextResponse.json(
+        { message: "Token and password are required" },
+        { status: 400 },
+      );
     }
 
     const tokenHash = crypto.createHash("sha256").update(token).digest("hex");
@@ -103,10 +103,10 @@ export async function POST(req: Request) {
         { route },
         (Date.now() - startTime) / 1000,
       );
-      return NextResponse.json({
-        status: 400,
-        message: "Invalid or Expired token",
-      });
+      return NextResponse.json(
+        { message: "Invalid or Expired token" },
+        { status: 400 },
+      );
     }
 
     const hashedPassword = await bcrypt.hash(password, 10);


### PR DESCRIPTION
## What this fixes
Closes #198

## Description
The reset-password endpoint was returning HTTP 200 on validation 
errors with the status code incorrectly placed inside the JSON 
body. Frontend code checking response.ok or response.status 
would treat these as successful responses.

## Changes made
`app/api/auth/reset-password/route.ts`

Two instances fixed:
- Line 80 — "Token and password required": moved `status: 400` 
  from JSON body to HTTP response second argument
- Line 106 — "Invalid or Expired token": same fix applied

Both now return proper HTTP 400 instead of HTTP 200 with a 
misleading status field in the body.

## Type
- [x] Bug fix

## Suggested Labels
`level-1` `bug` `backend`