### PR TITLE
Improve sidebar menu item styling for readability

### DIFF
--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -139,6 +139,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       },
     ],
   };
+  const wrapMenuItemClassName =
+    "h-auto items-start whitespace-normal break-words leading-snug";
 
   return (
     <Sidebar variant="floating" {...props}>
@@ -218,7 +220,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                           {item.isLoading ? (
                             <HistorySideBarSkeleton />
                           ) : (
-                            <SidebarMenuButton asChild isActive={item.isActive}>
+                            <SidebarMenuButton
+                              asChild
+                              isActive={item.isActive}
+                              className={wrapMenuItemClassName}
+                            >
                               {item.title === "New Chat" ? (
                                 <a href={item.url}>{item.title}</a>
                               ) : (
@@ -247,7 +253,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                     <Skeleton className="h-4 w-24" />
                   </div>
                 ) : (
-                  <SidebarMenuButton asChild>
+                  <SidebarMenuButton asChild className={wrapMenuItemClassName}>
                     <Button
                       variant="ghost"
                       className="cursor-pointer w-full justify-start"
@@ -255,7 +261,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                     >
                       <Link
                         href={DOC_ROUTES.PROFILE.ROOT}
-                        className="flex items-center"
+                        className="flex items-start"
                       >
                         <div
                           className={cn(


### PR DESCRIPTION
## Description

Allow multi-line wrapping for long user names and chat titles in AppSidebar to prevent truncation.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🎨 Style/UI changes

## Related Issues

Fixes #200 


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have tested my changes locally
- [ ] Any dependent changes have been merged and published
