### PR TITLE
fix: add minimum password length validation on reset and update password endpoints

### DIFF
--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -112,7 +112,7 @@ export async function POST(req: Request) {
     if (!password || password.length < 8) {
       return NextResponse.json(
         { message: "Password must be at least 8 characters" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -109,6 +109,13 @@ export async function POST(req: Request) {
       );
     }
 
+    if (!password || password.length < 8) {
+      return NextResponse.json(
+        { message: "Password must be at least 8 characters" },
+        { status: 400 }
+      );
+    }
+
     const hashedPassword = await bcrypt.hash(password, 10);
 
     // Update password

--- a/app/api/auth/updatePassword/route.ts
+++ b/app/api/auth/updatePassword/route.ts
@@ -84,7 +84,7 @@ export async function POST(req: NextRequest) {
     if (!newPassword || newPassword.length < 8) {
       return NextResponse.json(
         { message: "Password must be at least 8 characters" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 

--- a/app/api/auth/updatePassword/route.ts
+++ b/app/api/auth/updatePassword/route.ts
@@ -81,6 +81,13 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    if (!newPassword || newPassword.length < 8) {
+      return NextResponse.json(
+        { message: "Password must be at least 8 characters" },
+        { status: 400 }
+      );
+    }
+
     const newHashedPassword = await bcrypt.hash(newPassword, 10);
 
     const dbEnd2 = databaseQueryDurationSeconds.startTimer({


### PR DESCRIPTION
## What this fixes
Closes #204

## Description
The reset-password and updatePassword endpoints accepted any 
password value including a single character with no validation 
before hashing. Users could set extremely weak passwords leaving 
their accounts vulnerable to brute force.

The signup endpoint correctly uses Zod validation but these 
two endpoints bypassed it entirely.

## Changes made
- `app/api/auth/reset-password/route.ts` — added length check 
  on `password` before bcrypt.hash
- `app/api/auth/updatePassword/route.ts` — added length check 
  on `newPassword` before bcrypt.hash

Both now return HTTP 400 if password is less than 8 characters.

## Type
- [x] Bug fix / Security fix

## Suggested Labels
`level-1` `security` `backend`