### PR TITLE
fix: throw at startup if JWT_SECRET env variable is not set

### DIFF
--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -1,6 +1,9 @@
 import jwt from "jsonwebtoken";
 
-const JWT_SECRET = process.env.JWT_SECRET || "";
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error("FATAL: JWT_SECRET environment variable is required");
+}
 
 export interface JWTPayload {
   id: string;

--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -1,9 +1,10 @@
 import jwt from "jsonwebtoken";
 
-const JWT_SECRET = process.env.JWT_SECRET;
-if (!JWT_SECRET) {
+const jwtSecret = process.env.JWT_SECRET;
+if (!jwtSecret) {
   throw new Error("FATAL: JWT_SECRET environment variable is required");
 }
+const JWT_SECRET: string = jwtSecret;
 
 export interface JWTPayload {
   id: string;


### PR DESCRIPTION
## What this fixes
Closes #206

## Description
JWT_SECRET in lib/jwt.ts was silently falling back to an empty 
string if the environment variable was not set. Any JWT signed 
with an empty string can be forged by anyone who reads the 
source code, allowing attackers to create valid auth tokens 
for any user account.

The server now throws a fatal error at startup if JWT_SECRET 
is missing, making the misconfiguration immediately visible 
instead of silently running insecurely.

## Change made
`lib/jwt.ts` line 3

- Removed `|| ""` empty string fallback
- Added startup guard that throws if JWT_SECRET is not set

## Before / After
- Before: Server starts silently with empty JWT secret
- After: Server throws FATAL error at startup if JWT_SECRET 
  is missing

## Type
- [x] Bug fix / Security fix

## Suggested Labels
`level-1` `security` `backend`