### PR TITLE
fix: correct typo Verfied to Verified in grievance error message

### DIFF
--- a/app/api/grievance/route.ts
+++ b/app/api/grievance/route.ts
@@ -70,7 +70,7 @@ export async function POST(req: NextRequest) {
       httpRequestsTotal.inc({ route, method, status_code: "401" });
       apiGatewayErrorsTotal.inc({ status_code: "401" });
       return NextResponse.json(
-        { success: false, error: "User not Verfied" },
+        { success: false, error: "User not Verified" },
         { status: 401 },
       );
     }


### PR DESCRIPTION
## What this fixes
Closes #208

## Description
There was a typo in a user-facing error message in the 
grievance route. "Verfied" was missing the letter "i".

## Change made
`app/api/grievance/route.ts` line 74

- FROM: `{ success: false, error: "User not Verfied" }`
- TO:   `{ success: false, error: "User not Verified" }`

## Type
- [x] Bug fix

## Suggested Labels
`level-1` `bug` `backend`