### PR TITLE
fix(grievance): Verfied -> Verified in error message

### DIFF
--- a/app/api/grievance/route.ts
+++ b/app/api/grievance/route.ts
@@ -70,7 +70,7 @@ export async function POST(req: NextRequest) {
       httpRequestsTotal.inc({ route, method, status_code: "401" });
       apiGatewayErrorsTotal.inc({ status_code: "401" });
       return NextResponse.json(
-        { success: false, error: "User not Verfied" },
+        { success: false, error: "User not Verified" },
         { status: 401 },
       );
     }


### PR DESCRIPTION
## Summary

Closes #208. Single-character spelling fix in a user-facing 401 error message.

## Why this matters

`app/api/grievance/route.ts:73` returned `"User not Verfied"` in the JSON response body when an authenticated request lacked email verification. Anyone hitting that path or piping the response into a UI sees the misspelled word. One-character correction.

## Description

Fix the spelling from `"User not Verfied"` to `"User not Verified"` in the grievance route's 401 response body.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related Issues

Fixes #208

## Screenshots (if applicable)

Not applicable - one-character string change in a JSON error body.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (n/a - no docs change needed)
- [x] My changes generate no new warnings (one-character string edit)
- [x] No new test surface introduced; existing tests unaffected

## Additional Notes

```
$ grep -rn "Verfied" --include="*.ts" --include="*.tsx" .
(empty)
$ grep -n "User not Verified" app/api/grievance/route.ts
73:        { success: false, error: "User not Verified" },
```

AI-assisted.
