### PR TITLE
Adds missing return keyword before NextResponse.json()

### DIFF
--- a/app/api/generate/[id]/route.ts
+++ b/app/api/generate/[id]/route.ts
@@ -65,7 +65,7 @@ export async function GET(
         { route },
         (Date.now() - startTime) / 1000,
       );
-      NextResponse.json({ status: 404, message: "User not Found" });
+      return NextResponse.json({ status: 404, message: "User not Found" });
     }
 
     if (user?.isVerified === false) {


### PR DESCRIPTION
## Description

Adds missing return keyword before NextResponse.json() in the GET handler of /api/generate/[id]. Without it, when the authenticated user's database record is not found, execution falls through to the catch block and returns a 500 Internal Server Error instead of the intended 404 Not Found.
Type of Change
- 🐛 Bug fix (non-breaking change which fixes an issue)
Related Issues
Fixes #228

### Checklist
- My code follows the project's style guidelines
- I have performed a self-review of my code
- My changes generate no new warnings
- I have tested my changes locally

### ### Requested Labels

GSSoC 2026 , gssoc:approved , level:beginner , quality:clean ,  type:refactor