### PR TITLE
fix: show server error messages in signup form instead of silent failure

### DIFF
--- a/components/main/signUpForm.tsx
+++ b/components/main/signUpForm.tsx
@@ -67,7 +67,11 @@ const SignUpForm = () => {
       }
     } catch (err) {
       setLoading(false);
-      console.error("Signup failed:", err);
+      if (axios.isAxiosError(err) && err.response?.data?.message) {
+        setErrors({ email: err.response.data.message });
+      } else {
+        setErrors({ email: "Something went wrong. Please try again." });
+      }
     }
   };
 


### PR DESCRIPTION
## Description
The signup form's catch block was silently swallowing server errors — only logging to console and resetting loading state. Users saw no feedback when signup failed (e.g., "User already exists", network error). Added error extraction from the axios response and display via the existing setErrors state, with a fallback generic message for unknown errors.

### Type of Change
- 🐛 Bug fix (non-breaking change which fixes an issue)

### Related Issues
Fixes #236 

### Affected File
components/main/signUpForm.tsx

### Checklist
- My code follows the project's style guidelines
- I have performed a self-review of my code
- My changes generate no new warnings
- I have tested my changes locally

### Requested Labels
GSSoC 2026 , gssoc:approved , level:beginner , quality:clean ,  type:refactor