### PR TITLE
fix: return NextResponse.next() explicitly in proxy middleware

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -5,7 +5,7 @@ const DEFAULT_MAX_BYTES = 750 * 1024;
 const MAX_BYTES = Number(process.env.API_BODY_LIMIT_BYTES) || DEFAULT_MAX_BYTES;
 
 export function proxy(req: NextRequest) {
-  if (!["POST", "PUT", "PATCH"].includes(req.method)) return;
+  if (!["POST", "PUT", "PATCH"].includes(req.method)) return NextResponse.next();
 
   const declared = req.headers.get("content-length");
   if (!declared) return;

--- a/proxy.ts
+++ b/proxy.ts
@@ -5,7 +5,8 @@ const DEFAULT_MAX_BYTES = 750 * 1024;
 const MAX_BYTES = Number(process.env.API_BODY_LIMIT_BYTES) || DEFAULT_MAX_BYTES;
 
 export function proxy(req: NextRequest) {
-  if (!["POST", "PUT", "PATCH"].includes(req.method)) return NextResponse.next();
+  if (!["POST", "PUT", "PATCH"].includes(req.method))
+    return NextResponse.next();
 
   const declared = req.headers.get("content-length");
   if (!declared) return;


### PR DESCRIPTION
## Description
Explicitly returns NextResponse.next() for non-matching HTTP methods in the proxy middleware instead of relying on implicit undefined return. While Next.js currently treats both the same, the explicit return is the standard pattern and prevents breakage if the middleware execution model changes.

### Type of Change
- 🐛 Bug fix (non-breaking change which fixes an issue)

### Related Issues
Fixes #239 

### Checklist
- My code follows the project's style guidelines
- I have performed a self-review of my code
- My changes generate no new warnings
- I have tested my changes locally

### Requested Labels
GSSoC 2026 , gssoc:approved , level:beginner , quality:clean ,  type:refactor