### PR TITLE
fix: remove accidental subscription cancellation on grievance

### DIFF
--- a/app/api/grievance/route.ts
+++ b/app/api/grievance/route.ts
@@ -75,21 +75,6 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const dbStart = Date.now();
-    await db.user.update({
-      where: {
-        // @ts-expect-error id is added to the session in the session callback
-        id: session.user.id,
-      },
-      data: {
-        subscriptionStatus: "cancelled",
-      },
-    });
-    databaseQueryDurationSeconds.observe(
-      { operation: "findFirst" },
-      (Date.now() - dbStart) / 1000,
-    );
-
     // Prepare email data
     const emailData = {
       ...validation.data,


### PR DESCRIPTION
## Description
Removes a `db.user.update()` block in the grievance submission endpoint that was incorrectly cancelling the user's subscription on every complaint submission. This appears to be leftover code from a cancellation endpoint. Filing a grievance should only notify the admin team, not modify the user's subscription status.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues
Fixes #241

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested my changes locally

### Requested Labels
GSSoC 2026 , gssoc:approved , level:beginner , quality:clean ,  type:refactor