### PR TITLE
fix: add missing auth check to improve-diagram endpoint

### DIFF
--- a/app/api/github-generation/[id]/improve-diagram/route.ts
+++ b/app/api/github-generation/[id]/improve-diagram/route.ts
@@ -19,6 +19,7 @@ export async function POST(req: NextRequest) {
   const method = "POST";
 
   const session = await getServerSession(authOptions);
+  // @ts-expect-error id is added to the session in the session callback
   if (!session?.user?.id) {
     httpRequestsTotal.inc({ route, method, status_code: "401" });
     return NextResponse.json(

--- a/app/api/github-generation/[id]/improve-diagram/route.ts
+++ b/app/api/github-generation/[id]/improve-diagram/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { openAiLLM } from "@/lib/ai/helperClient";
 import {
   GITHUB_AI_SUGGEST_PROMPT,
@@ -15,6 +17,15 @@ import {
 export async function POST(req: NextRequest) {
   const route = "/api/github-generation/[id]/improve-diagram";
   const method = "POST";
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    httpRequestsTotal.inc({ route, method, status_code: "401" });
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
   let aiRequested = false;
   let aiFailureRecorded = false;
 


### PR DESCRIPTION
## Description
Adds authentication check to the improve-diagram endpoint. Previously any unauthenticated user could call it and invoke OpenAI's LLM using the system's paid API key, creating an open AI proxy that could be abused to rack up costs.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Related Issues
Fixes #243 

### Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested my changes locally

### Requested Labels
GSSoC 2026 , gssoc:approved , level:beginner , quality:clean ,  type:refactor