### PR TITLE
feat: add copy action to task cards

### DIFF
--- a/app/(protected)/generate/[id]/tasks/components/TaskCard.tsx
+++ b/app/(protected)/generate/[id]/tasks/components/TaskCard.tsx
@@ -1,6 +1,7 @@
+import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Clock, AlertCircle, Copy } from "lucide-react";
+import { Clock, AlertCircle, Copy, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface Task {
@@ -19,6 +20,7 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, allTasks }: TaskCardProps) {
+  const [copied, setCopied] = useState(false);
   const getPriorityColor = (priority: string) => {
     switch (priority) {
       case "high":
@@ -67,6 +69,12 @@ export default function TaskCard({ task, allTasks }: TaskCardProps) {
     await navigator.clipboard.writeText(
       `[${priority}] ${task.title}: ${task.description}`,
     );
+
+    setCopied(true);
+
+    setTimeout(() => {
+      setCopied(false);
+    }, 1500);
   };
 
   return (
@@ -95,11 +103,15 @@ export default function TaskCard({ task, allTasks }: TaskCardProps) {
             variant="ghost"
             size="icon"
             onClick={handleCopyTask}
-            aria-label={`Copy task ${task.title}`}
-            title="Copy task"
+            aria-label={copied ? "Task copied" : `Copy task ${task.title}`}
+            title={copied ? "Copied" : "Copy task"}
             className="h-8 w-8 shrink-0"
           >
-            <Copy className="h-4 w-4" />
+            {copied ? (
+              <Check className="h-4 w-4" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
           </Button>
 
           <div className="flex items-center gap-1 text-sm text-muted-foreground shrink-0">

--- a/app/(protected)/generate/[id]/tasks/components/TaskCard.tsx
+++ b/app/(protected)/generate/[id]/tasks/components/TaskCard.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Clock, AlertCircle } from "lucide-react";
+import { Clock, AlertCircle, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface Task {
   id: string;
@@ -59,6 +60,15 @@ export default function TaskCard({ task, allTasks }: TaskCardProps) {
       .join(", ");
   };
 
+  const handleCopyTask = async () => {
+    const priority =
+      task.priority.charAt(0).toUpperCase() + task.priority.slice(1);
+
+    await navigator.clipboard.writeText(
+      `[${priority}] ${task.title}: ${task.description}`,
+    );
+  };
+
   return (
     <Card className="hover:shadow-md transition-shadow">
       <CardHeader className="pb-3">
@@ -80,6 +90,18 @@ export default function TaskCard({ task, allTasks }: TaskCardProps) {
             </div>
             <CardTitle className="text-lg">{task.title}</CardTitle>
           </div>
+
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleCopyTask}
+            aria-label={`Copy task ${task.title}`}
+            title="Copy task"
+            className="h-8 w-8 shrink-0"
+          >
+            <Copy className="h-4 w-4" />
+          </Button>
+
           <div className="flex items-center gap-1 text-sm text-muted-foreground shrink-0">
             <Clock className="h-4 w-4" />
             <span>{task.estimatedHours}h</span>


### PR DESCRIPTION
## Description

Added a copy-to-clipboard button for each task card on the Task Breakdown page.

Users can now quickly copy task details in the following format:

```txt
[Priority] Task Title: Task Description
```

The copy action uses the browser Clipboard API and is accessible through a small copy icon displayed on every task card.

## Type of Change

* [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
* [x] ✨ New feature (non-breaking change which adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] 📚 Documentation update
* [ ] 🔧 Configuration change
* [ ] ♻️ Refactoring (no functional changes)
* [x] 🎨 Style/UI changes

## Related Issues

Fixes #156 


## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have tested my changes locally
* [ ] Any dependent changes have been merged and published