### PR TITLE
bug: fix text overflow in generation failed card

### DIFF
--- a/app/(protected)/generate/components/GeneratePage.tsx
+++ b/app/(protected)/generate/components/GeneratePage.tsx
@@ -458,11 +458,13 @@ export default function GeneratePage() {
         <Card className="border-destructive/20 bg-destructive/5 rounded-2xl">
           <CardContent className="p-6 flex items-start gap-3">
             <AlertCircle className="w-5 h-5 text-destructive shrink-0 mt-0.5" />
-            <div className="space-y-1">
+            <div className="space-y-1 min-w-0">
               <p className="font-semibold text-destructive">
                 Generation Failed
               </p>
-              <p className="text-sm text-destructive/80">{generateError}</p>
+              <p className="text-sm text-destructive/80 break-words whitespace-pre-wrap max-h-32 overflow-auto">
+                {generateError}
+              </p>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Description

Fixed UI overflow issue in the “Generation Failed” error block where long unbroken error messages (stack traces / API responses / JSON strings) were overflowing outside the container.

Updated text wrapping behavior to ensure error messages properly wrap within the card without breaking layout or causing horizontal overflow.

## Type of Change
 
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ]  ✨ New feature (non-breaking change which adds functionality)
- [ ]  💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  📚 Documentation update
- [ ]  🔧 Configuration change
- [ ]  ♻️ Refactoring (no functional changes)
- [ ]  🎨 Style/UI changes

## Related Issues

Fixes #274

## Screenshots

- Before: Error text overflowed outside the container in “Generation Failed” Card.
<img width="940" height="476" alt="image" src="https://github.com/user-attachments/assets/8c84f039-d0c3-4619-8bec-a1e891d2b033" />

- After: Error text wraps properly within the card with no layout break.
<img width="940" height="477" alt="image" src="https://github.com/user-attachments/assets/12d6d27f-18d9-42ac-9deb-732f98875235" />



## Checklist

- [x]  My code follows the project's style guidelines
- [x]  I have performed a self-review of my code
- [x]  I have commented my code where necessary
- [x]  I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [x]  I have tested my changes locally
- [x]  Any dependent changes have been merged and published

## Additional Notes

Improved error message rendering by enforcing proper text wrapping for long unbroken strings to ensure UI consistency across all screen sizes.