### PR TITLE
feat: add centralized DiagramContext provider for diagram state management [DIAG-04]

### DIFF
--- a/app/(protected)/generate/[id]/page.tsx
+++ b/app/(protected)/generate/[id]/page.tsx
@@ -9,6 +9,7 @@ import { useGetGenerationById } from "../hooks/useGetGenerationById";
 import { useDeleteGenerationById } from "../hooks/useDeleteGenerationById";
 import { useUpdateGeneration } from "@/hooks/useUpdateGeneration";
 import { useHistory } from "@/lib/contexts/HistoryContext";
+import { DiagramProvider } from "@/lib/contexts/DiagramContext";
 import { downloadMarkdownFile } from "../utils/generate-markdown";
 import { toast } from "sonner";
 import {
@@ -45,7 +46,8 @@ import { cleanMermaidString } from "../utils/cleanMermaidString";
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
-export default function GenerationPage() {
+// wrapped around a function to better organize the code and separate the provider logic from the page content
+function GenerationPageContent() {
   const { id } = useParams();
   const router = useRouter();
   const { getGenerationById, isLoading, error } = useGetGenerationById();
@@ -586,5 +588,13 @@ export default function GenerationPage() {
         </div>
       </div>
     </div>
+  );
+}
+// The main page component that wraps the content with the DiagramProvider to provide context to all child components.
+export default function GenerationPage() {
+  return (
+    <DiagramProvider>
+      <GenerationPageContent />
+    </DiagramProvider>
   );
 }

--- a/lib/contexts/DiagramContext.tsx
+++ b/lib/contexts/DiagramContext.tsx
@@ -1,0 +1,70 @@
+"use client";
+import {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  Dispatch,
+  SetStateAction,
+} from "react";
+import { DiagramLayer } from "@/types/diagram";
+
+// This context manages the state related to the diagram, such as selected nodes, search queries, active layers, and D3 visualization settings.
+type DiagramContextType = {
+  selectedNodeId: string | null;
+  setSelectedNodeId: Dispatch<SetStateAction<string | null>>;
+
+  searchQuery: string;
+  setSearchQuery: Dispatch<SetStateAction<string>>;
+
+  activeLayers: DiagramLayer[];
+  setActiveLayers: Dispatch<SetStateAction<DiagramLayer[]>>;
+
+  isD3Enabled: boolean;
+  setIsD3Enabled: Dispatch<SetStateAction<boolean>>;
+};
+
+// Create the context with an undefined default value. The provider will ensure that the context is properly initialized.
+const DiagramContext = createContext<DiagramContextType | undefined>(undefined);
+
+// The provider component that wraps the application and provides the diagram state to its children.
+export function DiagramProvider({ children }: { children: ReactNode }) {
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const [activeLayers, setActiveLayers] = useState<DiagramLayer[]>([]);
+
+  const [isD3Enabled, setIsD3Enabled] = useState(true);
+
+  return (
+    <DiagramContext.Provider
+      value={{
+        selectedNodeId,
+        setSelectedNodeId,
+
+        searchQuery,
+        setSearchQuery,
+
+        activeLayers,
+        setActiveLayers,
+
+        isD3Enabled,
+        setIsD3Enabled,
+      }}
+    >
+      {children}
+    </DiagramContext.Provider>
+  );
+}
+
+// Custom hook to access the diagram context. It ensures that the context is used within a provider and provides type safety.
+export function useDiagram() {
+  const context = useContext(DiagramContext);
+
+  if (!context) {
+    throw new Error("useDiagram must be used within a DiagramProvider");
+  }
+
+  return context;
+}


### PR DESCRIPTION
## Description

Implemented a centralized diagram state provider to manage interactive diagram-related state across the `(protected)/generate/[id]` route without prop drilling.

### Changes made:

* Created `lib/contexts/DiagramContext.tsx`
* Added centralized state for:

  * `selectedNodeId`
  * `searchQuery`
  * `activeLayers`
  * `isD3Enabled`
* Added `DiagramProvider` and `useDiagram` hook
* Wrapped the `generate/[id]` page with `DiagramProvider`
* Refactored page structure by separating content into `GenerationPageContent` for cleaner provider integration

## Type of Change

* [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
* [x] ✨ New feature (non-breaking change which adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] 📚 Documentation update
* [ ] 🔧 Configuration change
* [x] ♻️ Refactoring (no functional changes)
* [ ] 🎨 Style/UI changes

## Related Issues

Fixes #261

## Screenshots (if applicable)

N/A

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have tested my changes locally
* [ ] Any dependent changes have been merged and published

## Additional Notes

This PR lays the groundwork for future interactive diagram features such as node selection, diagram filtering, layer toggling, and D3 state management by centralizing shared diagram state into a dedicated React context provider.
