### PR TITLE
fix: return 500 on webhook DB failure to trigger retry

### DIFF
--- a/app/api/payment/webhook/route.ts
+++ b/app/api/payment/webhook/route.ts
@@ -123,6 +123,13 @@ export async function POST(req: NextRequest) {
     dbEnd();
   } catch (error) {
     console.error("❌ Failed to update DB:", error);
+    httpRequestsTotal.inc({ route, method, status_code: "500" });
+    apiGatewayErrorsTotal.inc({ status_code: "500" });
+    end();
+    return NextResponse.json(
+      { success: false, message: "Failed to update user" },
+      { status: 500 },
+    );
   }
 
   httpRequestsTotal.inc({ route, method, status_code: "200" });


### PR DESCRIPTION
## Description

Fixes the payment webhook handler silently returning 200 when the database update fails. If the DB update fails (network error, user not found), the endpoint now returns 500 so the payment provider retries the webhook. Previously the error was logged but execution fell through to a 200 success response, meaning users were charged but never received their upgraded plan.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #282 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
