### PR TITLE
fix: use 403 instead of 401 for plan restriction responses

### DIFF
--- a/app/api/generate/[id]/frontendStructure/route.ts
+++ b/app/api/generate/[id]/frontendStructure/route.ts
@@ -80,11 +80,11 @@ export async function POST(
     const isPro =
       user?.plan !== "free" || !!user?.geminiApiKey || !!user?.openaiApiKey;
     if (!isPro) {
-      httpRequestsTotal.inc({ route, method, status_code: "401" });
-      apiGatewayErrorsTotal.inc({ status_code: "401" });
+      httpRequestsTotal.inc({ route, method, status_code: "403" });
+      apiGatewayErrorsTotal.inc({ status_code: "403" });
       end();
       return NextResponse.json({
-        status: 401,
+        status: 403,
         message: "Purchase the pro version to use this feature",
       });
     }

--- a/app/api/generate/[id]/route.ts
+++ b/app/api/generate/[id]/route.ts
@@ -297,7 +297,7 @@ export async function PUT(
     const isPro =
       user?.plan !== "free" || !!user?.geminiApiKey || !!user?.openaiApiKey;
     if (!isPro) {
-      apiGatewayErrorsTotal.inc({ status_code: "401" });
+      apiGatewayErrorsTotal.inc({ status_code: "403" });
       httpRequestDurationSeconds.observe(
         { route },
         (Date.now() - startTime) / 1000,
@@ -307,7 +307,7 @@ export async function PUT(
           success: false,
           message: "Purchase the pro version to use this feature",
         },
-        { status: 401 },
+        { status: 403 },
       );
     }
 


### PR DESCRIPTION
## Description

Fixes two endpoints that incorrectly return HTTP 401 (Unauthenticated) when blocking free users from pro features. 401 means the user is not logged in. Since the user is authenticated but on a free plan, the correct status is 403 (Forbidden). This allows monitoring to distinguish real auth failures from plan restrictions.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #291 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested my changes locally

### Requested Labels
GSSoC 2026 , gssoc:approved , level:beginner , quality:clean ,  type:bug