### PR TITLE
fix: add aria-labels to password visibility toggle buttons

### DIFF
--- a/app/(protected)/profile/components/ChangePasswordDialog.tsx
+++ b/app/(protected)/profile/components/ChangePasswordDialog.tsx
@@ -151,6 +151,11 @@ export function ChangePasswordDialog({
               />
               <Button
                 type="button"
+                aria-label={
+                  showPasswords.previousPassword
+                    ? "Hide password"
+                    : "Show password"
+                }
                 variant="ghost"
                 size="sm"
                 className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
@@ -187,6 +192,9 @@ export function ChangePasswordDialog({
               />
               <Button
                 type="button"
+                aria-label={
+                  showPasswords.newPassword ? "Hide password" : "Show password"
+                }
                 variant="ghost"
                 size="sm"
                 className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
@@ -223,6 +231,11 @@ export function ChangePasswordDialog({
               />
               <Button
                 type="button"
+                aria-label={
+                  showPasswords.confirmPassword
+                    ? "Hide password"
+                    : "Show password"
+                }
                 variant="ghost"
                 size="sm"
                 className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"

--- a/components/main/loginForm.tsx
+++ b/components/main/loginForm.tsx
@@ -113,6 +113,7 @@ const LoginInFormContent = () => {
                 />
                 <button
                   type="button"
+                  aria-label={showPassword ? "Hide password" : "Show password"}
                   onClick={() => setShowPassword(!showPassword)}
                   className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
                 >


### PR DESCRIPTION
## Description

This PR improves accessibility by adding aria-label attributes to password visibility toggle buttons (Eye / EyeOff) in the login and change password forms.

These buttons were icon-only controls, which could make it difficult for screen readers to identify their purpose. The added labels allow assistive technologies to announce the buttons correctly.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🎨 Style/UI changes

## Related Issues

Fixes #295

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [ ] Any dependent changes have been merged and published

## Additional Notes

Added dynamic accessibility labels:

"Show password" when the password is hidden
"Hide password" when the password is visible

No functional or visual changes were introduced.
