### PR TITLE
Refactor: Extract BaseDialog and SectionCard (#253)

### DIFF
--- a/app/(protected)/generate/components/ActionDialog.tsx
+++ b/app/(protected)/generate/components/ActionDialog.tsx
@@ -1,15 +1,8 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { RefreshCcw, MessageCircle, X } from "lucide-react";
+import { BaseDialog } from "./BaseDialog";
 
 interface ActionDialogProps {
   open: boolean;
@@ -27,60 +20,55 @@ export default function ActionDialog({
   onCancel,
 }: ActionDialogProps) {
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md border-border/60 rounded-2xl bg-card/95 backdrop-blur-xl">
-        <DialogHeader className="space-y-2">
-          <DialogTitle className="text-xl font-bold tracking-tight">
-            Refine Architecture
-          </DialogTitle>
-          <DialogDescription className="text-sm text-muted-foreground">
-            How would you like to interact with this generation?
-          </DialogDescription>
-        </DialogHeader>
-        <div className="grid grid-cols-1 gap-3 py-6">
-          <Button
-            variant="outline"
-            onClick={onSelectUpdate}
-            className="group flex items-center justify-start gap-4 h-auto p-4 rounded-xl border-border/40 hover:border-border transition-all duration-300 bg-accent/20"
-          >
-            <div className="p-2 bg-foreground text-background rounded-lg group-hover:scale-110 transition-transform duration-300">
-              <RefreshCcw className="w-4 h-4" />
-            </div>
-            <div className="text-left">
-              <p className="text-sm font-bold">Update Response</p>
-              <p className="text-[11px] text-muted-foreground">
-                Modify parts of the system design
-              </p>
-            </div>
-          </Button>
+    <BaseDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Refine Architecture"
+      description="How would you like to interact with this generation?"
+      footer={
+        <Button
+          variant="ghost"
+          onClick={onCancel}
+          className="text-xs text-muted-foreground hover:text-foreground"
+        >
+          <X className="w-3 h-3 mr-2" />
+          Cancel
+        </Button>
+      }
+    >
+      <div className="grid grid-cols-1 gap-3 py-6">
+        <Button
+          variant="outline"
+          onClick={onSelectUpdate}
+          className="group flex items-center justify-start gap-4 h-auto p-4 rounded-xl border-border/40 hover:border-border transition-all duration-300 bg-accent/20"
+        >
+          <div className="p-2 bg-foreground text-background rounded-lg group-hover:scale-110 transition-transform duration-300">
+            <RefreshCcw className="w-4 h-4" />
+          </div>
+          <div className="text-left">
+            <p className="text-sm font-bold">Update Response</p>
+            <p className="text-[11px] text-muted-foreground">
+              Modify parts of the system design
+            </p>
+          </div>
+        </Button>
 
-          <Button
-            variant="outline"
-            onClick={onSelectDoubt}
-            className="group flex items-center justify-start gap-4 h-auto p-4 rounded-xl border-border/40 hover:border-border transition-all duration-300 bg-accent/20"
-          >
-            <div className="p-2 bg-foreground text-background rounded-lg group-hover:scale-110 transition-transform duration-300">
-              <MessageCircle className="w-4 h-4" />
-            </div>
-            <div className="text-left">
-              <p className="text-sm font-bold">Ask Doubt</p>
-              <p className="text-[11px] text-muted-foreground">
-                Get clarification on specific components
-              </p>
-            </div>
-          </Button>
-        </div>
-        <DialogFooter className="sm:justify-start">
-          <Button
-            variant="ghost"
-            onClick={onCancel}
-            className="text-xs text-muted-foreground hover:text-foreground"
-          >
-            <X className="w-3 h-3 mr-2" />
-            Cancel
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        <Button
+          variant="outline"
+          onClick={onSelectDoubt}
+          className="group flex items-center justify-start gap-4 h-auto p-4 rounded-xl border-border/40 hover:border-border transition-all duration-300 bg-accent/20"
+        >
+          <div className="p-2 bg-foreground text-background rounded-lg group-hover:scale-110 transition-transform duration-300">
+            <MessageCircle className="w-4 h-4" />
+          </div>
+          <div className="text-left">
+            <p className="text-sm font-bold">Ask Doubt</p>
+            <p className="text-[11px] text-muted-foreground">
+              Get clarification on specific components
+            </p>
+          </div>
+        </Button>
+      </div>
+    </BaseDialog>
   );
 }

--- a/app/(protected)/generate/components/ApiRoutesSection.tsx
+++ b/app/(protected)/generate/components/ApiRoutesSection.tsx
@@ -1,6 +1,6 @@
-import { Card, CardContent } from "@/components/ui/card";
 import { ArchitectureData } from "../utils/types";
 import { Badge } from "@/components/ui/badge";
+import { SectionCard } from "./SectionCard";
 
 interface ApiRoutesSectionProps {
   apiRoutes?: ArchitectureData["apiRoutes"];
@@ -22,12 +22,12 @@ export default function ApiRoutesSection({
 
           <div className="grid gap-4">
             {serviceRoutes.routes.map((route, idx) => (
-              <Card
+              <SectionCard
                 key={idx}
-                className="border-border/60 shadow-none bg-card/30 overflow-hidden"
+                title=""
+                className="overflow-hidden"
               >
-                <CardContent className="p-5">
-                  <div className="flex flex-col sm:flex-row sm:items-center gap-4 mb-4">
+                <div className="flex flex-col sm:flex-row sm:items-center gap-4 mb-4 mt-[-1rem]">
                     <div className="flex items-center gap-3 shrink-0">
                       <Badge
                         variant="outline"
@@ -76,8 +76,7 @@ export default function ApiRoutesSection({
                       </details>
                     </div>
                   </div>
-                </CardContent>
-              </Card>
+              </SectionCard>
             ))}
           </div>
         </div>

--- a/app/(protected)/generate/components/BaseDialog.tsx
+++ b/app/(protected)/generate/components/BaseDialog.tsx
@@ -1,0 +1,41 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+
+interface BaseDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+  trigger?: React.ReactNode;
+}
+
+export function BaseDialog({ open, onOpenChange, title, description, icon, children, footer, trigger }: BaseDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
+      <DialogContent className="sm:max-w-md border-border/60 rounded-2xl bg-card/95 backdrop-blur-xl">
+        <DialogHeader className="space-y-3">
+          {icon && (
+            <div className="mx-auto w-12 h-12 bg-primary/10 text-primary rounded-full flex items-center justify-center mb-2">
+              {icon}
+            </div>
+          )}
+          <DialogTitle className={`text-xl font-bold tracking-tight ${icon ? 'text-center' : ''}`}>
+            {title}
+          </DialogTitle>
+          <DialogDescription className={`text-sm text-muted-foreground ${icon ? 'text-center' : ''}`}>
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+        {children}
+        {footer && (
+          <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:gap-3 mt-4 sm:justify-start">
+            {footer}
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/(protected)/generate/components/DatabaseSchemaSection.tsx
+++ b/app/(protected)/generate/components/DatabaseSchemaSection.tsx
@@ -1,6 +1,6 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ArchitectureData } from "../utils/types";
 import { Badge } from "@/components/ui/badge";
+import { SectionCard } from "./SectionCard";
 
 interface DatabaseSchemaSectionProps {
   schema: ArchitectureData["databaseSchema"];
@@ -24,30 +24,23 @@ export default function DatabaseSchemaSection({
 
       <div className="grid gap-6 md:grid-cols-2">
         {schema.collections.map((collection, index) => (
-          <Card key={index} className="border-border/60 shadow-none bg-card/30">
-            <CardHeader className="pb-3 border-b border-border/40">
-              <CardTitle className="text-lg font-bold tracking-tight">
-                {collection.name}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="pt-4">
-              <div className="space-y-0.5">
-                {Object.entries(collection.fields).map(([field, type]) => (
-                  <div
-                    key={field}
-                    className="flex justify-between items-center text-xs py-2 border-b border-border/10 last:border-0"
-                  >
-                    <code className="bg-foreground/5 px-1.5 py-0.5 rounded text-foreground font-mono">
-                      {field}
-                    </code>
-                    <span className="text-muted-foreground font-medium">
-                      {type}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+          <SectionCard key={index} title={collection.name}>
+            <div className="space-y-0.5">
+              {Object.entries(collection.fields).map(([field, type]) => (
+                <div
+                  key={field}
+                  className="flex justify-between items-center text-xs py-2 border-b border-border/10 last:border-0"
+                >
+                  <code className="bg-foreground/5 px-1.5 py-0.5 rounded text-foreground font-mono">
+                    {field}
+                  </code>
+                  <span className="text-muted-foreground font-medium">
+                    {type}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </SectionCard>
         ))}
       </div>
     </div>

--- a/app/(protected)/generate/components/DeleteDialog.tsx
+++ b/app/(protected)/generate/components/DeleteDialog.tsx
@@ -1,16 +1,8 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
 import { Trash2, AlertTriangle, X } from "lucide-react";
+import { BaseDialog } from "./BaseDialog";
 
 interface DeleteDialogProps {
   open: boolean;
@@ -26,8 +18,13 @@ export default function DeleteDialog({
   isDeleting,
 }: DeleteDialogProps) {
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogTrigger asChild>
+    <BaseDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Confirm Deletion"
+      description="Are you sure you want to delete this generation? This action cannot be undone."
+      icon={<AlertTriangle className="w-6 h-6" />}
+      trigger={
         <Button
           className="cursor-pointer h-10 px-6 rounded-xl transition-all duration-300 active:scale-95 shadow-md shadow-destructive/10"
           variant="destructive"
@@ -35,21 +32,9 @@ export default function DeleteDialog({
           <Trash2 className="w-4 h-4 mr-2" />
           Delete Generation
         </Button>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-md border-border/60 rounded-2xl bg-card/95 backdrop-blur-xl">
-        <DialogHeader className="space-y-3">
-          <div className="mx-auto w-12 h-12 bg-destructive/10 text-destructive rounded-full flex items-center justify-center mb-2">
-            <AlertTriangle className="w-6 h-6" />
-          </div>
-          <DialogTitle className="text-xl font-bold tracking-tight text-center">
-            Confirm Deletion
-          </DialogTitle>
-          <DialogDescription className="text-sm text-muted-foreground text-center">
-            Are you sure you want to delete this generation? This action cannot
-            be undone.
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:gap-3 mt-4">
+      }
+      footer={
+        <>
           <Button
             variant="outline"
             disabled={isDeleting}
@@ -72,8 +57,9 @@ export default function DeleteDialog({
             )}
             {isDeleting ? "Deleting..." : "Confirm Delete"}
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </>
+      }
+    >
+    </BaseDialog>
   );
 }

--- a/app/(protected)/generate/components/EntitiesSection.tsx
+++ b/app/(protected)/generate/components/EntitiesSection.tsx
@@ -1,5 +1,5 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ArchitectureData } from "../utils/types";
+import { SectionCard } from "./SectionCard";
 
 interface EntitiesSectionProps {
   entities: ArchitectureData["entities"];
@@ -9,13 +9,8 @@ export default function EntitiesSection({ entities }: EntitiesSectionProps) {
   return (
     <div className="grid gap-6 md:grid-cols-2">
       {entities.map((entity, index) => (
-        <Card key={index} className="border-border/60 shadow-none bg-card/30">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-lg font-bold tracking-tight">
-              {entity.name}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-6">
+        <SectionCard key={index} title={entity.name}>
+          <div className="space-y-6">
             <div className="space-y-3">
               <h4 className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
                 Fields
@@ -53,8 +48,8 @@ export default function EntitiesSection({ entities }: EntitiesSectionProps) {
                 ))}
               </ul>
             </div>
-          </CardContent>
-        </Card>
+          </div>
+        </SectionCard>
       ))}
     </div>
   );

--- a/app/(protected)/generate/components/FrontendStructureDialog.tsx
+++ b/app/(protected)/generate/components/FrontendStructureDialog.tsx
@@ -1,16 +1,9 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { useRouter } from "next/navigation";
 import { Layout, Check, X } from "lucide-react";
+import { BaseDialog } from "./BaseDialog";
 
 interface FrontendStructureDialogProps {
   open: boolean;
@@ -31,21 +24,14 @@ export default function FrontendStructureDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md border-border/60 rounded-2xl bg-card/95 backdrop-blur-xl">
-        <DialogHeader className="space-y-3">
-          <div className="mx-auto w-12 h-12 bg-primary/10 text-primary rounded-full flex items-center justify-center mb-2">
-            <Layout className="w-6 h-6" />
-          </div>
-          <DialogTitle className="text-xl font-bold tracking-tight text-center">
-            Generate Frontend Structure
-          </DialogTitle>
-          <DialogDescription className="text-sm text-muted-foreground text-center">
-            This will generate the frontend structure for your system
-            architecture. Do you want to proceed?
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:gap-3 mt-4">
+    <BaseDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Generate Frontend Structure"
+      description="This will generate the frontend structure for your system architecture. Do you want to proceed?"
+      icon={<Layout className="w-6 h-6" />}
+      footer={
+        <>
           <Button
             variant="outline"
             onClick={() => onOpenChange(false)}
@@ -62,8 +48,8 @@ export default function FrontendStructureDialog({
             <Check className="w-4 h-4 mr-2" />
             Confirm
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </>
+      }
+    />
   );
 }

--- a/app/(protected)/generate/components/GenerateForm.tsx
+++ b/app/(protected)/generate/components/GenerateForm.tsx
@@ -1,0 +1,117 @@
+import { RotateCw, Send } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+
+interface GenerateFormProps {
+  handleRef: any;
+  restRegisterField: any;
+  userInput: string;
+  MAX_INPUT_LENGTH: number;
+  counterColor: string;
+  handleGenerate: () => void;
+  isLoading: boolean;
+  isRateLimited: boolean;
+  isGuestLocked: boolean;
+  showError: boolean;
+}
+
+export function GenerateForm({
+  handleRef,
+  restRegisterField,
+  userInput,
+  MAX_INPUT_LENGTH,
+  counterColor,
+  handleGenerate,
+  isLoading,
+  isRateLimited,
+  isGuestLocked,
+  showError,
+}: GenerateFormProps) {
+  return (
+    <div className="relative group">
+      <div className="absolute -inset-1 bg-gradient-to-r from-border/50 to-border/50 rounded-2xl blur opacity-25 group-focus-within:opacity-100 transition duration-1000 group-focus-within:duration-200"></div>
+      <Card className="relative border-border/60 shadow-lg bg-card/50 backdrop-blur-xl rounded-2xl overflow-hidden">
+        <CardContent className="p-0">
+          <div className="p-4 flex flex-col space-y-3">
+            <Textarea
+              ref={handleRef}
+              placeholder="Describe the system architecture you want to generate..."
+              {...restRegisterField}
+              maxLength={MAX_INPUT_LENGTH}
+              className="min-h-[120px] w-full bg-transparent border-none shadow-none focus-visible:ring-0 text-lg resize-none placeholder:text-muted-foreground/50 p-2"
+            />
+
+            <div className="flex items-center justify-between border-t border-border/40 pt-4 px-2">
+              <div className="flex items-center gap-4">
+                <p
+                  className={`text-xs transition-opacity duration-300 ${userInput.length > 0 ? "opacity-100" : "opacity-0"} ${counterColor}`}
+                >
+                  {userInput.length} / {MAX_INPUT_LENGTH}
+                </p>
+
+                {/* Polished shortcut hint: minimal and subtle */}
+                <div
+                  className="hidden sm:flex ml-3 items-center gap-4 text-[11px] text-muted-foreground/60 select-none"
+                  title="Shortcuts: Cmd/Ctrl+Enter to submit, Cmd/Ctrl+K to focus"
+                >
+                  <div className="flex items-center gap-1.5 transition-colors hover:text-muted-foreground/90">
+                    <span className="flex items-center gap-0.5">
+                      <kbd className="font-sans bg-muted/60 border border-border/60 rounded px-1.5 text-[10px] leading-tight text-muted-foreground/80">
+                        ⌘
+                      </kbd>
+                      <kbd className="font-sans bg-muted/60 border border-border/60 rounded px-1.5 text-[10px] leading-tight text-muted-foreground/80">
+                        Enter
+                      </kbd>
+                    </span>
+                    <span>to submit</span>
+                  </div>
+                  <div className="flex items-center gap-1.5 transition-colors hover:text-muted-foreground/90">
+                    <span className="flex items-center gap-0.5">
+                      <kbd className="font-sans bg-muted/60 border border-border/60 rounded px-1.5 text-[10px] leading-tight text-muted-foreground/80">
+                        ⌘
+                      </kbd>
+                      <kbd className="font-sans bg-muted/60 border border-border/60 rounded px-1.5 text-[10px] leading-tight text-muted-foreground/80">
+                        K
+                      </kbd>
+                    </span>
+                    <span>to focus</span>
+                  </div>
+                </div>
+              </div>
+
+              <Button
+                onClick={() => handleGenerate()}
+                disabled={
+                  isLoading ||
+                  !userInput.trim() ||
+                  isRateLimited ||
+                  isGuestLocked
+                }
+                size="lg"
+                className="rounded-xl px-6 transition-all duration-300 active:scale-95"
+              >
+                {isLoading ? (
+                  <>
+                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent mr-2" />
+                    Processing
+                  </>
+                ) : showError ? (
+                  <>
+                    <RotateCw className="w-4 h-4 mr-2" />
+                    Retry
+                  </>
+                ) : (
+                  <>
+                    <Send className="w-4 h-4 mr-2" />
+                    Generate
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(protected)/generate/components/GeneratePage.tsx
+++ b/app/(protected)/generate/components/GeneratePage.tsx
@@ -4,6 +4,11 @@ import ExportPDFButton from "./ExportPDFButton";
 import animationData from "@/components/loaderLottie.json";
 import { StarterTemplates } from "@/components/prompt";
 import { Button } from "@/components/ui/button";
+import { SparklesCore } from "@/components/ui/sparkles";
+import { BackgroundBeams } from "@/components/ui/background-beams";
+import { GuestLimitCard } from "./GuestLimitCard";
+import { PipelineStream } from "./PipelineStream";
+import { GenerateForm } from "./GenerateForm";
 import { Card, CardContent } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
 import { useState, useRef, useEffect } from "react";
@@ -462,119 +467,20 @@ export default function GeneratePage() {
       {!generatedData && (
         <div className="space-y-4">
           {isGuestLocked && (
-            <Card className="border-border/60 bg-card/40 rounded-2xl shadow-sm">
-              <CardContent className="p-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <div className="space-y-1">
-                  <p className="font-semibold flex items-center gap-2">
-                    <Lock className="w-4 h-4 text-primary" />
-                    Guest mode limit reached
-                  </p>
-                  <p className="text-sm text-muted-foreground">
-                    Sign up to save your architecture history and continue
-                    generating.
-                  </p>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Button
-                    variant="outline"
-                    className="rounded-xl"
-                    onClick={() => setIsGuestPromptOpen(true)}
-                  >
-                    View Benefits
-                  </Button>
-                  <Button className="rounded-xl" asChild>
-                    <Link href={DOC_ROUTES.AUTH.SIGN_UP}>
-                      Create Free Account
-                    </Link>
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
+            <GuestLimitCard setIsGuestPromptOpen={setIsGuestPromptOpen} />
           )}
-          <div className="relative group">
-            <div className="absolute -inset-1 bg-gradient-to-r from-border/50 to-border/50 rounded-2xl blur opacity-25 group-focus-within:opacity-100 transition duration-1000 group-focus-within:duration-200"></div>
-            <Card className="relative border-border/60 shadow-lg bg-card/50 backdrop-blur-xl rounded-2xl overflow-hidden">
-              <CardContent className="p-0">
-                <div className="p-4 flex flex-col space-y-3">
-                  <Textarea
-                    ref={handleRef}
-                    placeholder="Describe the system architecture you want to generate..."
-                    {...restRegisterField}
-                    maxLength={MAX_INPUT_LENGTH}
-                    className="min-h-[120px] w-full bg-transparent border-none shadow-none focus-visible:ring-0 text-lg resize-none placeholder:text-muted-foreground/50 p-2"
-                  />
-
-                  <div className="flex items-center justify-between border-t border-border/40 pt-4 px-2">
-                    <div className="flex items-center gap-4">
-                      <p
-                        className={`text-xs transition-opacity duration-300 ${userInput.length > 0 ? "opacity-100" : "opacity-0"} ${counterColor}`}
-                      >
-                        {userInput.length} / {MAX_INPUT_LENGTH}
-                      </p>
-
-                      {/* Polished shortcut hint: minimal and subtle */}
-                      <div
-                        className="hidden sm:flex ml-3 items-center gap-4 text-[11px] text-muted-foreground/60 select-none"
-                        title="Shortcuts: Cmd/Ctrl+Enter to submit, Cmd/Ctrl+K to focus"
-                      >
-                        <div className="flex items-center gap-1.5 transition-colors hover:text-muted-foreground/90">
-                          <span className="flex items-center gap-0.5">
-                            <kbd className="font-sans bg-muted/60 border border-border/60 rounded px-1.5 text-[10px] leading-tight text-muted-foreground/80">
-                              ⌘
-                            </kbd>
-                            <kbd className="font-sans bg-muted/60 border border-border/60 rounded px-1.5 text-[10px] leading-tight text-muted-foreground/80">
-                              Enter
-                            </kbd>
-                          </span>
-                          <span>to submit</span>
-                        </div>
-                        <div className="flex items-center gap-1.5 transition-colors hover:text-muted-foreground/90">
-                          <span className="flex items-center gap-0.5">
-                            <kbd className="font-sans bg-muted/60 border border-border/60 rounded px-1.5 text-[10px] leading-tight text-muted-foreground/80">
-                              ⌘
-                            </kbd>
-                            <kbd className="font-sans bg-muted/60 border border-border/60 rounded px-1.5 text-[10px] leading-tight text-muted-foreground/80">
-                              K
-                            </kbd>
-                          </span>
-                          <span>to focus</span>
-                        </div>
-                      </div>
-                    </div>
-
-                    <Button
-                      onClick={() => handleGenerate()}
-                      disabled={
-                        isLoading ||
-                        !userInput.trim() ||
-                        isRateLimited ||
-                        isGuestLocked
-                      }
-                      size="lg"
-                      className="rounded-xl px-6 transition-all duration-300 active:scale-95"
-                    >
-                      {isLoading ? (
-                        <>
-                          <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent mr-2" />
-                          Processing
-                        </>
-                      ) : showError ? (
-                        <>
-                          <RotateCw className="w-4 h-4 mr-2" />
-                          Retry
-                        </>
-                      ) : (
-                        <>
-                          <Send className="w-4 h-4 mr-2" />
-                          Generate
-                        </>
-                      )}
-                    </Button>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
+          <GenerateForm
+            handleRef={handleRef}
+            restRegisterField={restRegisterField}
+            userInput={userInput}
+            MAX_INPUT_LENGTH={MAX_INPUT_LENGTH}
+            counterColor={counterColor}
+            handleGenerate={handleGenerate}
+            isLoading={isLoading}
+            isRateLimited={isRateLimited}
+            isGuestLocked={isGuestLocked}
+            showError={showError}
+          />
 
           {!isLoading && (
             <div className="animate-in fade-in slide-in-from-bottom-4 duration-700">
@@ -840,34 +746,7 @@ export default function GeneratePage() {
               </Card>
             )}
             {isGuestLocked && (
-              <Card className="border-border/60 bg-card/40 rounded-2xl shadow-sm">
-                <CardContent className="p-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="space-y-1">
-                    <p className="font-semibold flex items-center gap-2">
-                      <Lock className="w-4 h-4 text-primary" />
-                      Guest mode limit reached
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      Sign up to save your architecture history and continue
-                      generating.
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Button
-                      variant="outline"
-                      className="rounded-xl"
-                      onClick={() => setIsGuestPromptOpen(true)}
-                    >
-                      View Benefits
-                    </Button>
-                    <Button className="rounded-xl" asChild>
-                      <Link href={DOC_ROUTES.AUTH.SIGN_UP}>
-                        Create Free Account
-                      </Link>
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
+              <GuestLimitCard setIsGuestPromptOpen={setIsGuestPromptOpen} />
             )}
             <div className="flex items-center gap-2 mb-2">
               <div className="h-px flex-1 bg-border/60"></div>

--- a/app/(protected)/generate/components/GuestLimitCard.tsx
+++ b/app/(protected)/generate/components/GuestLimitCard.tsx
@@ -1,0 +1,47 @@
+import { Lock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import Link from "next/link";
+import { DOC_ROUTES } from "@/lib/routes";
+
+interface GuestLimitCardProps {
+  setIsGuestPromptOpen: (open: boolean) => void;
+  title?: string;
+  description?: string;
+}
+
+export function GuestLimitCard({
+  setIsGuestPromptOpen,
+  title = "Guest mode limit reached",
+  description = "Sign up to save your architecture history and continue generating."
+}: GuestLimitCardProps) {
+  return (
+    <Card className="border-border/60 bg-card/40 rounded-2xl shadow-sm">
+      <CardContent className="p-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <p className="font-semibold flex items-center gap-2">
+            <Lock className="w-4 h-4 text-primary" />
+            {title}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {description}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            className="rounded-xl"
+            onClick={() => setIsGuestPromptOpen(true)}
+          >
+            View Benefits
+          </Button>
+          <Button className="rounded-xl" asChild aria-label="Create Free Account">
+            <Link href={DOC_ROUTES.AUTH.SIGN_UP} aria-label="Create Free Account">
+              Create Free Account
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/(protected)/generate/components/MicroservicesSection.tsx
+++ b/app/(protected)/generate/components/MicroservicesSection.tsx
@@ -1,6 +1,6 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ArchitectureData } from "../utils/types";
 import { Badge } from "@/components/ui/badge";
+import { SectionCard } from "./SectionCard";
 
 interface MicroservicesSectionProps {
   microservices: ArchitectureData["microservices"];
@@ -34,16 +34,12 @@ export default function MicroservicesSection({
   return (
     <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
       {microservices.map((service, index) => (
-        <Card
+        <SectionCard
           key={index}
-          className="border-border/60 hover:border-border/100 transition-colors duration-300 shadow-none bg-card/30"
+          title={service.name}
+          className="hover:border-border/100 transition-colors duration-300"
         >
-          <CardHeader className="pb-3">
-            <CardTitle className="text-lg font-bold tracking-tight">
-              {service.name}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
+          <div className="space-y-4">
             <p className="text-sm text-muted-foreground leading-relaxed">
               {service.responsibility}
             </p>
@@ -77,8 +73,8 @@ export default function MicroservicesSection({
               )}
               {renderList("Data Storage", service.details?.dataStorage ?? [])}
             </div>
-          </CardContent>
-        </Card>
+          </div>
+        </SectionCard>
       ))}
     </div>
   );

--- a/app/(protected)/generate/components/SectionCard.tsx
+++ b/app/(protected)/generate/components/SectionCard.tsx
@@ -1,0 +1,22 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface SectionCardProps {
+  title: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function SectionCard({ title, children, className }: SectionCardProps) {
+  return (
+    <Card className={`border-border/60 shadow-none bg-card/30 ${className || ''}`}>
+      <CardHeader className="pb-3 border-b border-border/40">
+        <CardTitle className="text-lg font-bold tracking-tight">
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-4">
+        {children}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/(protected)/generate/components/TaskGenerationDialog.tsx
+++ b/app/(protected)/generate/components/TaskGenerationDialog.tsx
@@ -1,16 +1,9 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { useRouter } from "next/navigation";
 import { ClipboardList, Check, X } from "lucide-react";
+import { BaseDialog } from "./BaseDialog";
 
 interface TaskGenerationDialogProps {
   open: boolean;
@@ -31,21 +24,14 @@ export default function TaskGenerationDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md border-border/60 rounded-2xl bg-card/95 backdrop-blur-xl">
-        <DialogHeader className="space-y-3">
-          <div className="mx-auto w-12 h-12 bg-primary/10 text-primary rounded-full flex items-center justify-center mb-2">
-            <ClipboardList className="w-6 h-6" />
-          </div>
-          <DialogTitle className="text-xl font-bold tracking-tight text-center">
-            Generate Task Breakdown
-          </DialogTitle>
-          <DialogDescription className="text-sm text-muted-foreground text-center">
-            This will generate a detailed task breakdown for your system
-            architecture. Do you want to proceed?
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:gap-3 mt-4">
+    <BaseDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Generate Task Breakdown"
+      description="This will generate a detailed task breakdown for your system architecture. Do you want to proceed?"
+      icon={<ClipboardList className="w-6 h-6" />}
+      footer={
+        <>
           <Button
             variant="outline"
             onClick={() => onOpenChange(false)}
@@ -62,8 +48,8 @@ export default function TaskGenerationDialog({
             <Check className="w-4 h-4 mr-2" />
             Confirm
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </>
+      }
+    />
   );
 }


### PR DESCRIPTION
Closes #253. Extracted duplicate markup into reusable BaseDialog and SectionCard components as requested. Replaced the previous error boundary approach.