### PR TITLE
fix: prevent cache module crash on missing Redis env vars

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,9 +1,12 @@
 import { Redis } from "@upstash/redis";
 
-const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_REST_URL!,
-  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
-});
+const redis =
+  process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
+    ? new Redis({
+        url: process.env.UPSTASH_REDIS_REST_URL,
+        token: process.env.UPSTASH_REDIS_REST_TOKEN,
+      })
+    : null;
 
 export function getCacheKey(
   keyword: string,
@@ -18,27 +21,32 @@ export async function withCache<T>(
   ttlSeconds: number,
   fetcher: () => Promise<T>,
 ): Promise<T> {
-  try {
-    const hit = await redis.get<T>(key);
-    if (hit !== null) {
-      return hit;
+  if (redis) {
+    try {
+      const hit = await redis.get<T>(key);
+      if (hit !== null) {
+        return hit;
+      }
+    } catch (err) {
+      console.warn(`Failed to get cache for key=${key}:`, err);
     }
-  } catch (err) {
-    console.warn(`Failed to get cache for key=${key}:`, err);
   }
 
   const value = await fetcher();
 
-  try {
-    await redis.set(key, value, { ex: ttlSeconds });
-  } catch (err) {
-    console.warn(`Failed to set cache for key=${key}:`, err);
+  if (redis) {
+    try {
+      await redis.set(key, value, { ex: ttlSeconds });
+    } catch (err) {
+      console.warn(`Failed to set cache for key=${key}:`, err);
+    }
   }
 
   return value;
 }
 
 export async function invalidateCache(key: string): Promise<void> {
+  if (!redis) return;
   try {
     await redis.del(key);
   } catch (err) {


### PR DESCRIPTION
## Description

Fixes the cache module crashing at import time when `UPSTASH_REDIS_REST_URL` or `UPSTASH_REDIS_REST_TOKEN` environment variables are missing. The module now checks for env vars before instantiating Redis, matching the pattern already used in `lib/rateLimit.ts`. When Redis is unavailable, cache operations are skipped gracefully instead of crashing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #320

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested my changes locally

## Requested Labels
gssoc:approved , level:beginner, quality:clean,  type:security