### PR TITLE
fix: add missing IP rate limiting on signup endpoint

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -4,6 +4,7 @@ import bcrypt from "bcrypt";
 import { generateOTP } from "@/lib/otpgenerator";
 import { sendMail } from "@/lib/mailer";
 import { signUpSchema } from "@/lib/validation/signUpschema";
+import { signupRateLimitIP } from "@/lib/rateLimit";
 import { otpEmailTemplate } from "@/components/email-template/otpEmailTemplate";
 import {
   httpRequestsTotal,
@@ -21,6 +22,24 @@ export async function POST(req: NextRequest) {
   httpRequestsTotal.inc({ route, method });
 
   try {
+    const ip =
+      req.headers.get("x-forwarded-for") ||
+      req.headers.get("x-real-ip") ||
+      "unknown";
+
+    const ipLimit = await signupRateLimitIP.limit(ip);
+    if (!ipLimit.success) {
+      apiGatewayErrorsTotal.inc({ status_code: "429" });
+      httpRequestDurationSeconds.observe(
+        { route },
+        (Date.now() - startTime) / 1000,
+      );
+      return NextResponse.json(
+        { message: "Too many signup attempts. Please try again later." },
+        { status: 429 },
+      );
+    }
+
     const body = await req.json();
     const parsedData = signUpSchema.safeParse(body);
 

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -101,6 +101,16 @@ export const otpRateLimit = redis
       limit: async (key: string) => checkInMemoryLimit(key, 1, 60000),
     } as unknown as Ratelimit);
 
+export const signupRateLimitIP = redis
+  ? new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(3, "1 h"), // 3 signups per IP per hour
+      analytics: true,
+    })
+  : ({
+      limit: async (key: string) => checkInMemoryLimit(key, 3, 3600000),
+    } as unknown as Ratelimit);
+
 export const loginRateLimitIP = redis
   ? new Ratelimit({
       redis,


### PR DESCRIPTION
## Description

Adds IP-based rate limiting to the signup endpoint to prevent mass account creation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🎨 Style/UI changes

## Related Issues

Fixes #329 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

Uses the same pattern as `loginRateLimitIP` and `otpRateLimit`. Falls back to in-memory tracking when Redis is unavailable.
