### PR TITLE
fix: remove duplicate userGenerationsTotal increment in frontendStructure route

### DIFF
--- a/app/api/generate/[id]/frontendStructure/route.ts
+++ b/app/api/generate/[id]/frontendStructure/route.ts
@@ -142,9 +142,6 @@ Generate a complete frontend architecture for this backend system.`),
       userApiKeys.openaiApiKey,
     );
 
-    // @ts-expect-error id is added to the session in the session callback
-    userGenerationsTotal.inc({ user_id: session.user.id });
-
     let content: string;
     if (typeof response.content === "string") {
       content = response.content;


### PR DESCRIPTION
## Description

Removes duplicate `userGenerationsTotal` increment in frontendStructure route that caused the metric to report double the actual generation count.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🎨 Style/UI changes

## Related Issues

Fixes #331 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
