### PR TITLE
fix: show toast for unverified email generation errors

### DIFF
--- a/app/(protected)/generate/components/GeneratePage.tsx
+++ b/app/(protected)/generate/components/GeneratePage.tsx
@@ -11,6 +11,7 @@ import { useForm } from "react-hook-form";
 import { ArchitectureData } from "../utils/types";
 import { useGenerateSystem } from "../hooks/useGenerateSystem";
 import StarRating from "@/components/ui/star-rating";
+import { toast } from "sonner";
 
 import { useSession } from "next-auth/react";
 import Link from "next/link";
@@ -344,12 +345,21 @@ export default function GeneratePage() {
             );
           }
         }
-      } else {
-        setGeneratedData(null);
       }
     } catch (error) {
       console.error("Generation failed:", error);
       setGeneratedData(null);
+
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      if (errorMessage.includes("Email is not verified")) {
+        toast.error(
+          "Email not verified. Please verify your email before generating architectures.",
+        );
+      } else {
+        toast.error(errorMessage);
+      }
     }
   };
 

--- a/app/(protected)/generate/hooks/useGenerateSystem.ts
+++ b/app/(protected)/generate/hooks/useGenerateSystem.ts
@@ -59,7 +59,9 @@ export function useGenerateSystem(refetchHistory?: () => Promise<void>) {
         }
 
         throw new Error(
-          errorBody.error || `HTTP error! status: ${response.status}`,
+          errorBody.error ||
+            errorBody.message ||
+            `HTTP error! status: ${response.status}`,
         );
       }
 
@@ -162,16 +164,15 @@ export function useGenerateSystem(refetchHistory?: () => Promise<void>) {
 
       return data;
     } catch (err) {
+      let errorMessage = "An error occurred";
       if (err instanceof Error && err.name === "AbortError") {
-        setError(
-          "Request timed out. Please check your connection and try again.",
-        );
-      } else {
-        const errorMessage =
-          err instanceof Error ? err.message : "An error occurred";
-        setError(errorMessage);
+        errorMessage =
+          "Request timed out. Please check your connection and try again.";
+      } else if (err instanceof Error) {
+        errorMessage = err.message;
       }
-      return null;
+      setError(errorMessage);
+      throw err;
     } finally {
       clearTimeout(timeoutId);
       setIsLoading(false);


### PR DESCRIPTION
## Description
Fixes the issue where architecture generation fails silently when an unverified user attempts to generate an architecture.

The frontend was only parsing the error field from API responses, while the backend returns the verification failure message in the message field. As a result, users received no clear feedback when generation failed due to an unverified email.

## Type of Change
This PR:
    Adds support for parsing API responses that return a message field.
    Displays a Sonner toast notification when an email verification error occurs.
    Shows toast notifications for other generation failures.
    Preserves existing success behavior and loading state handling.


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🎨 Style/UI changes

## Related Issues

Fixess 153

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [ ] Any dependent changes have been merged and published

## Additional Notes
Root cause:
The backend returns:

{
  "status": 401,
  "message": "Email is not verified"
}

but the frontend only checked errorBody.error, causing the verification message to be lost and preventing meaningful user feedback.

TypeScript compilation was verified using:

npm run typecheck
