### PR TITLE
feat(diagram): add layer filtering toggles [DIAG-11]

### DIFF
--- a/components/diagram/FloatingSearch.tsx
+++ b/components/diagram/FloatingSearch.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState, useRef } from "react";
 import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { useDiagram } from "@/lib/contexts/DiagramContext";
@@ -15,10 +15,13 @@ type FloatingSearchProps = {
  * A small, reusable floating search input that lives above the diagram canvas.
  * - Controlled by `DiagramContext.searchQuery`
  * - Updates `setSearchQuery` on every change
+ * - Shrinks to icon on mobile if unfocused and empty
  */
 export const FloatingSearch: React.FC<FloatingSearchProps> = React.memo(
   function FloatingSearch({ position = "left", className }) {
     const { searchQuery, setSearchQuery } = useDiagram();
+    const [isFocused, setIsFocused] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
 
     const handleChange = React.useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -27,24 +30,37 @@ export const FloatingSearch: React.FC<FloatingSearchProps> = React.memo(
       [setSearchQuery],
     );
 
+    const isExpanded = isFocused || !!searchQuery;
+
     return (
       <div
         className={
-          "absolute top-4 z-20 flex items-center gap-2 p-2 rounded-xl border border-border/40 bg-background/60 backdrop-blur-sm shadow-sm max-w-[min(60ch,90%)] " +
+          "absolute top-4 z-20 flex items-center gap-2 p-2 rounded-xl border border-border/40 bg-background/60 backdrop-blur-sm shadow-sm transition-all duration-300 overflow-hidden " +
+          (isExpanded
+            ? "w-[calc(100%-10rem)] sm:w-80 "
+            : "w-10 sm:w-80 cursor-pointer ") +
           (position === "left" ? "left-4" : "right-4") +
           (className ? ` ${className}` : "")
         }
         role="search"
         aria-label="Search diagram"
+        onClick={() => {
+          if (!isExpanded) {
+            inputRef.current?.focus();
+          }
+        }}
       >
-        <Search className="w-4 h-4 text-muted-foreground" />
+        <Search className="w-5 h-5 ml-0.5 text-muted-foreground shrink-0" />
         <Input
+          ref={inputRef}
           id="diagram-search"
-          placeholder="Search services, components, or nodes..."
+          placeholder="Search components..."
           value={searchQuery}
           onChange={handleChange}
-          className="flex-1 min-w-0 !p-1 !pl-0 bg-transparent border-0 shadow-none"
-          aria-label="Search services, components, or nodes"
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          className={`flex-1 min-w-0 !p-1 !pl-0 bg-transparent border-0 shadow-none transition-opacity duration-300 ${isExpanded ? "opacity-100" : "opacity-0 sm:opacity-100"}`}
+          aria-label="Search components or nodes"
         />
       </div>
     );

--- a/components/diagram/InteractiveDiagram.tsx
+++ b/components/diagram/InteractiveDiagram.tsx
@@ -220,7 +220,7 @@ export default function InteractiveDiagram({
   const containerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
-  const { isD3Enabled, activeLayers } = useDiagram();
+  const { isD3Enabled, activeLayers, searchQuery } = useDiagram();
 
   const selectedIdRef = useRef<string | null>(null);
   const relations = useMemo(

--- a/components/diagram/InteractiveDiagram.tsx
+++ b/components/diagram/InteractiveDiagram.tsx
@@ -223,6 +223,13 @@ export default function InteractiveDiagram({
   const { isD3Enabled, activeLayers, searchQuery } = useDiagram();
   const searchQueryRef = useRef(searchQuery ?? "");
   const updateSearchHighlightRef = useRef<(() => void) | null>(null);
+  const activeLayersRef = useRef(activeLayers);
+  const updateLayerVisibilityRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    activeLayersRef.current = activeLayers;
+    updateLayerVisibilityRef.current?.();
+  }, [activeLayers]);
 
   useEffect(() => {
     searchQueryRef.current = searchQuery ?? "";
@@ -378,21 +385,9 @@ export default function InteractiveDiagram({
     const getNodeId = (node: string | DiagramNode) =>
       typeof node === "string" ? node : node.id;
 
-    const filteredNodes = systemGraph.nodes.filter((node) =>
-      activeLayers.includes(node.layer),
-    );
+    const nodes: DiagramNode[] = systemGraph.nodes.map((node) => ({ ...node }));
 
-    const filteredNodeIds = new Set(filteredNodes.map((node) => node.id));
-
-    const nodes: DiagramNode[] = filteredNodes.map((node) => ({ ...node }));
-
-    const links: DiagramLink[] = systemGraph.links
-      .filter(
-        (link) =>
-          filteredNodeIds.has(getNodeId(link.source)) &&
-          filteredNodeIds.has(getNodeId(link.target)),
-      )
-      .map((link) => ({ ...link }));
+    const links: DiagramLink[] = systemGraph.links.map((link) => ({ ...link }));
 
     const g = gZoom.append("g").attr("class", "d3-diagram");
 
@@ -469,6 +464,32 @@ export default function InteractiveDiagram({
 
           return text.includes(query) ? "drop-shadow(0 0 4px #60a5fa)" : null;
         });
+    };
+
+    const applyLayerVisibility = () => {
+      const visibleLayers = new Set(activeLayersRef.current);
+
+      node
+        .transition()
+        .duration(250)
+        .style("opacity", (d) => (visibleLayers.has(d.layer) ? 1 : 0))
+        .style("pointer-events", (d) =>
+          visibleLayers.has(d.layer) ? "auto" : "none",
+        );
+
+      link
+        .transition()
+        .duration(250)
+        .style("opacity", (d) => {
+          const source = d.source as DiagramNode;
+          const target = d.target as DiagramNode;
+
+          return visibleLayers.has(source.layer) &&
+            visibleLayers.has(target.layer)
+            ? 1
+            : 0;
+        })
+        .style("pointer-events", "none");
     };
 
     const applyHighlight = (selectedId: string | null) => {
@@ -580,14 +601,17 @@ export default function InteractiveDiagram({
     });
 
     updateSearchHighlightRef.current = applySearchHighlight;
+    updateLayerVisibilityRef.current = applyLayerVisibility;
+    applyLayerVisibility();
 
     // Clean up
     return () => {
       window.cancelAnimationFrame(raf);
       simulation.stop();
       updateSearchHighlightRef.current = null;
+      updateLayerVisibilityRef.current = null;
     };
-  }, [dimensions, fitToScreen, systemGraph, relations, activeLayers]);
+  }, [dimensions, fitToScreen, systemGraph, relations]);
 
   const handleZoomIn = () => {
     const svgSel = svgSelectionRef.current;

--- a/components/diagram/InteractiveDiagram.tsx
+++ b/components/diagram/InteractiveDiagram.tsx
@@ -221,6 +221,13 @@ export default function InteractiveDiagram({
   const svgRef = useRef<SVGSVGElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const { isD3Enabled, activeLayers, searchQuery } = useDiagram();
+  const searchQueryRef = useRef(searchQuery ?? "");
+  const updateSearchHighlightRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    searchQueryRef.current = searchQuery ?? "";
+    updateSearchHighlightRef.current?.();
+  }, [searchQuery]);
 
   const selectedIdRef = useRef<string | null>(null);
   const relations = useMemo(

--- a/components/diagram/InteractiveDiagram.tsx
+++ b/components/diagram/InteractiveDiagram.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+import LayerToggle from "@/components/diagram/LayerToggle";
 import { useDiagram } from "@/lib/contexts/DiagramContext";
 import { analyzeDiagramRelations } from "@/lib/utils/diagram-analyzer";
 import {
@@ -220,7 +220,7 @@ export default function InteractiveDiagram({
   const containerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
-  const { isD3Enabled } = useDiagram();
+  const { isD3Enabled, activeLayers } = useDiagram();
 
   const selectedIdRef = useRef<string | null>(null);
   const relations = useMemo(
@@ -368,9 +368,25 @@ export default function InteractiveDiagram({
     zoomRef.current = zoom;
     svgSel.call(zoom);
 
-    const nodes: DiagramNode[] = systemGraph.nodes.map((n) => ({ ...n }));
-    // parseMermaidToJSON already guarantees that the source and target exist in nodes.
-    const links: DiagramLink[] = systemGraph.links.map((l) => ({ ...l }));
+    const getNodeId = (node: string | DiagramNode) =>
+      typeof node === "string" ? node : node.id;
+
+    const filteredNodes = systemGraph.nodes.filter((node) =>
+      activeLayers.includes(node.layer),
+    );
+
+    const filteredNodeIds = new Set(filteredNodes.map((node) => node.id));
+
+    const nodes: DiagramNode[] = filteredNodes.map((node) => ({ ...node }));
+
+    const links: DiagramLink[] = systemGraph.links
+      .filter(
+        (link) =>
+          filteredNodeIds.has(getNodeId(link.source)) &&
+          filteredNodeIds.has(getNodeId(link.target)),
+      )
+      .map((link) => ({ ...link }));
+
     const g = gZoom.append("g").attr("class", "d3-diagram");
 
     const link = g
@@ -520,7 +536,7 @@ export default function InteractiveDiagram({
       window.cancelAnimationFrame(raf);
       simulation.stop();
     };
-  }, [dimensions, fitToScreen, systemGraph, relations]);
+  }, [dimensions, fitToScreen, systemGraph, relations, activeLayers]);
 
   const handleZoomIn = () => {
     const svgSel = svgSelectionRef.current;
@@ -548,6 +564,8 @@ export default function InteractiveDiagram({
     >
       {/* Floating search input (top-left) */}
       <FloatingSearch position="left" />
+      {/* Layer Filters */}
+      <LayerToggle />
       {/* Floating viewport controls */}
       <div className="absolute top-4 right-4 flex flex-col gap-2 z-10">
         <div className="inline-flex rounded-xl border border-border/40 bg-background/60 backdrop-blur p-1 shadow-sm gap-1">

--- a/components/diagram/InteractiveDiagram.tsx
+++ b/components/diagram/InteractiveDiagram.tsx
@@ -243,8 +243,6 @@ export default function InteractiveDiagram({
   );
   const getLinkOpacity = (d: DiagramLink) =>
     d.type === "fallback" ? 0.25 : 0.4;
-  const getLinkDashArray = (d: DiagramLink) =>
-    d.type === "async" ? "6 4" : null;
 
   // Use ResizeObserver to keep track of the container's dimensions
   useEffect(() => {
@@ -381,9 +379,6 @@ export default function InteractiveDiagram({
 
     zoomRef.current = zoom;
     svgSel.call(zoom);
-
-    const getNodeId = (node: string | DiagramNode) =>
-      typeof node === "string" ? node : node.id;
 
     const nodes: DiagramNode[] = systemGraph.nodes.map((node) => ({ ...node }));
 

--- a/components/diagram/InteractiveDiagram.tsx
+++ b/components/diagram/InteractiveDiagram.tsx
@@ -43,7 +43,7 @@ const DEFAULT_LAYER_COLORS: Record<DiagramLayer, string> = {
   Database: "#10b981",
   Infrastructure: "#f59e0b",
   External: "#ec4899",
-  Unknown: "var(--card)",
+  "Other Services": "var(--card)",
 };
 /**
  * Parse Mermaid-style class declarations such as
@@ -428,54 +428,60 @@ export default function InteractiveDiagram({
         .attr("pointer-events", "none");
     });
 
-    const applySearchHighlight = () => {
+    const updateVisualState = () => {
       const query = searchQueryRef.current.trim().toLowerCase();
+      const visibleLayers = new Set(activeLayersRef.current);
+      const selectedId = selectedIdRef.current;
 
-      if (!query) {
-        node.transition().duration(300).style("opacity", 1);
-
-        node
-          .selectAll("rect,circle,polygon,path")
-          .style("stroke-width", null)
-          .style("filter", null);
-
-        return;
+      const upstream = new Set<string>();
+      const downstream = new Set<string>();
+      if (selectedId) {
+        upstream.add(selectedId);
+        downstream.add(selectedId);
+        const rel = relations[selectedId];
+        if (rel) {
+          rel.ancestors.forEach((n) => upstream.add(n.id));
+          rel.descendants.forEach((n) => downstream.add(n.id));
+        }
       }
 
-      node
-        .transition()
-        .duration(300)
-        .style("opacity", (d) => {
-          const text = `${d.label} ${d.id}`.toLowerCase();
-          return text.includes(query) ? 1 : 0.2;
-        });
-
-      node
-        .selectAll<SVGElement, DiagramNode>("rect,circle,polygon,path")
-        .transition()
-        .duration(300)
-        .style("stroke-width", function (d) {
-          const text = `${d.label} ${d.id}`.toLowerCase();
-
-          return text.includes(query) ? "2px" : null;
-        })
-        .style("filter", function (d) {
-          const text = `${d.label} ${d.id}`.toLowerCase();
-
-          return text.includes(query) ? "drop-shadow(0 0 4px #60a5fa)" : null;
-        });
-    };
-
-    const applyLayerVisibility = () => {
-      const visibleLayers = new Set(activeLayersRef.current);
+      const onPath = (s: string, t: string) =>
+        (upstream.has(s) && upstream.has(t)) ||
+        (downstream.has(s) && downstream.has(t));
 
       node
         .transition()
         .duration(250)
-        .style("opacity", (d) => (visibleLayers.has(d.layer) ? 1 : 0))
+        .style("opacity", (d) => {
+          if (!visibleLayers.has(d.layer)) return 0;
+          let op = 1;
+          if (query) {
+            const text = `${d.label} ${d.id}`.toLowerCase();
+            if (!text.includes(query)) op = 0.2;
+          }
+          if (selectedId) {
+            if (!upstream.has(d.id) && !downstream.has(d.id)) op = 0.2;
+          }
+          return op;
+        })
         .style("pointer-events", (d) =>
           visibleLayers.has(d.layer) ? "auto" : "none",
         );
+
+      node
+        .selectAll<SVGElement, DiagramNode>("rect,circle,polygon,path")
+        .transition()
+        .duration(250)
+        .style("stroke-width", function (d) {
+          if (!query) return null;
+          const text = `${d.label} ${d.id}`.toLowerCase();
+          return text.includes(query) ? "2px" : null;
+        })
+        .style("filter", function (d) {
+          if (!query) return null;
+          const text = `${d.label} ${d.id}`.toLowerCase();
+          return text.includes(query) ? "drop-shadow(0 0 4px #60a5fa)" : null;
+        });
 
       link
         .transition()
@@ -483,72 +489,48 @@ export default function InteractiveDiagram({
         .style("opacity", (d) => {
           const source = d.source as DiagramNode;
           const target = d.target as DiagramNode;
-
-          return visibleLayers.has(source.layer) &&
-            visibleLayers.has(target.layer)
-            ? 1
-            : 0;
+          if (
+            !visibleLayers.has(source.layer) ||
+            !visibleLayers.has(target.layer)
+          ) {
+            return 0;
+          }
+          let op = getLinkOpacity(d);
+          if (selectedId) {
+            op = onPath(source.id, target.id) ? 0.9 : 0.05;
+          }
+          return op;
         })
-        .style("pointer-events", "none");
-    };
-
-    const applyHighlight = (selectedId: string | null) => {
-      if (!selectedId || !relations[selectedId]) {
-        node.style("opacity", 1);
-        link
-          .attr("stroke", "currentColor")
-          .attr("stroke-opacity", (d) => getLinkOpacity(d))
-          .attr("stroke-width", 2)
-          .attr("stroke-dasharray", (d) => getLinkDashArray(d));
-        return;
-      }
-
-      const rel = relations[selectedId];
-      const upstream = new Set<string>([
-        selectedId,
-        ...rel.ancestors.map((n) => n.id),
-      ]);
-      const downstream = new Set<string>([
-        selectedId,
-        ...rel.descendants.map((n) => n.id),
-      ]);
-      const onPath = (s: string, t: string) =>
-        (upstream.has(s) && upstream.has(t)) ||
-        (downstream.has(s) && downstream.has(t));
-
-      node.style("opacity", (d) =>
-        upstream.has(d.id) || downstream.has(d.id) ? 1 : 0.2,
-      );
-
-      link
-        .attr("stroke", (d) =>
-          onPath((d.source as DiagramNode).id, (d.target as DiagramNode).id)
-            ? "var(--primary)"
-            : "currentColor",
-        )
-        .attr("stroke-opacity", (d) =>
-          onPath((d.source as DiagramNode).id, (d.target as DiagramNode).id)
-            ? 0.9
-            : 0.05,
-        )
-        .attr("stroke-width", (d) =>
-          onPath((d.source as DiagramNode).id, (d.target as DiagramNode).id)
-            ? 3
-            : 2,
-        );
+        .style("pointer-events", "none")
+        .attr("stroke", (d) => {
+          if (selectedId) {
+            const source = d.source as DiagramNode;
+            const target = d.target as DiagramNode;
+            return onPath(source.id, target.id)
+              ? "var(--primary)"
+              : "currentColor";
+          }
+          return "currentColor";
+        })
+        .attr("stroke-width", (d) => {
+          if (selectedId) {
+            const source = d.source as DiagramNode;
+            const target = d.target as DiagramNode;
+            return onPath(source.id, target.id) ? 3 : 2;
+          }
+          return 2;
+        });
     };
 
     node.style("cursor", "pointer").on("click", (event, d) => {
       event.stopPropagation();
       selectedIdRef.current = d.id;
-      applyHighlight(selectedIdRef.current);
-      applySearchHighlight();
+      updateVisualState();
     });
 
     svgSel.on("click", () => {
       selectedIdRef.current = null;
-      applyHighlight(null);
-      applySearchHighlight();
+      updateVisualState();
     });
 
     // Initialize the physics engine
@@ -592,17 +574,14 @@ export default function InteractiveDiagram({
       fitToScreen({ padding: 28 });
     });
 
-    applyHighlight(selectedIdRef.current);
-    applySearchHighlight();
+    updateSearchHighlightRef.current = updateVisualState;
+    updateLayerVisibilityRef.current = updateVisualState;
+    updateVisualState();
 
     // Fit immediately once nodes exist (positions will update quickly)
     const raf = window.requestAnimationFrame(() => {
       fitToScreen({ padding: 28 });
     });
-
-    updateSearchHighlightRef.current = applySearchHighlight;
-    updateLayerVisibilityRef.current = applyLayerVisibility;
-    applyLayerVisibility();
 
     // Clean up
     return () => {

--- a/components/diagram/LayerToggle.tsx
+++ b/components/diagram/LayerToggle.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useDiagram } from "@/lib/contexts/DiagramContext";
+import { DiagramLayer } from "@/types/diagram";
+
+const layers: DiagramLayer[] = [
+  "Frontend",
+  "API",
+  "Database",
+  "Infrastructure",
+  "External",
+  "Unknown",
+];
+
+export default function LayerToggle() {
+  const { activeLayers, setActiveLayers } = useDiagram();
+
+  const toggleLayer = (layer: DiagramLayer) => {
+    setActiveLayers((prev) =>
+      prev.includes(layer)
+        ? prev.filter((item) => item !== layer)
+        : [...prev, layer],
+    );
+  };
+
+  return (
+    <div className="absolute left-4 top-16 z-10 rounded-xl border border-border/40 bg-background/70 p-3 shadow-sm backdrop-blur">
+      <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Layers
+      </p>
+
+      <div className="flex flex-col gap-2">
+        {layers.map((layer) => (
+          <label
+            key={layer}
+            className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground hover:text-foreground"
+          >
+            <input
+              type="checkbox"
+              checked={activeLayers.includes(layer)}
+              onChange={() => toggleLayer(layer)}
+              className="h-3.5 w-3.5"
+            />
+            {layer}
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/diagram/LayerToggle.tsx
+++ b/components/diagram/LayerToggle.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { useDiagram } from "@/lib/contexts/DiagramContext";
 import { DiagramLayer } from "@/types/diagram";
+import { ChevronDown, ChevronUp, Layers } from "lucide-react";
 
 const layers: DiagramLayer[] = [
   "Frontend",
@@ -14,6 +16,17 @@ const layers: DiagramLayer[] = [
 
 export default function LayerToggle() {
   const { activeLayers, setActiveLayers } = useDiagram();
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Auto-open on desktop, close on mobile
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (window.innerWidth >= 640) {
+        setIsOpen(true);
+      }
+    }, 0);
+    return () => clearTimeout(timer);
+  }, []);
 
   const toggleLayer = (layer: DiagramLayer) => {
     setActiveLayers((prev) =>
@@ -24,27 +37,41 @@ export default function LayerToggle() {
   };
 
   return (
-    <div className="absolute left-4 top-16 z-10 rounded-xl border border-border/40 bg-background/70 p-3 shadow-sm backdrop-blur">
-      <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-        Layers
-      </p>
+    <div className="absolute left-4 top-20 z-10 rounded-xl border border-border/40 bg-background/70 p-2 sm:p-3 shadow-sm backdrop-blur w-fit min-w-[140px]">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center justify-between w-full text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground"
+      >
+        <div className="flex items-center gap-2">
+          <Layers className="w-3.5 h-3.5" />
+          Layers
+        </div>
+        {isOpen ? (
+          <ChevronUp className="w-3.5 h-3.5" />
+        ) : (
+          <ChevronDown className="w-3.5 h-3.5" />
+        )}
+      </button>
 
-      <div className="flex flex-col gap-2">
-        {layers.map((layer) => (
-          <label
-            key={layer}
-            className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground hover:text-foreground"
-          >
-            <input
-              type="checkbox"
-              checked={activeLayers.includes(layer)}
-              onChange={() => toggleLayer(layer)}
-              className="h-3.5 w-3.5"
-            />
-            {layer}
-          </label>
-        ))}
-      </div>
+      {isOpen && (
+        <div className="flex flex-col gap-2 mt-3">
+          {layers.map((layer) => (
+            <label
+              key={layer}
+              className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <input
+                type="checkbox"
+                checked={activeLayers.includes(layer)}
+                onChange={() => toggleLayer(layer)}
+                className="h-3.5 w-3.5 shrink-0"
+              />
+              {layer}
+            </label>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/diagram/LayerToggle.tsx
+++ b/components/diagram/LayerToggle.tsx
@@ -9,7 +9,7 @@ const layers: DiagramLayer[] = [
   "Database",
   "Infrastructure",
   "External",
-  "Unknown",
+  "Other Services",
 ];
 
 export default function LayerToggle() {

--- a/lib/contexts/DiagramContext.tsx
+++ b/lib/contexts/DiagramContext.tsx
@@ -33,7 +33,13 @@ export function DiagramProvider({ children }: { children: ReactNode }) {
 
   const [searchQuery, setSearchQuery] = useState("");
 
-  const [activeLayers, setActiveLayers] = useState<DiagramLayer[]>([]);
+  const [activeLayers, setActiveLayers] = useState<DiagramLayer[]>([
+    "Frontend",
+    "API",
+    "Database",
+    "Infrastructure",
+    "External",
+  ]);
 
   const [isD3Enabled, setIsD3Enabled] = useState(false);
 

--- a/lib/utils/diagram-parser.ts
+++ b/lib/utils/diagram-parser.ts
@@ -137,7 +137,7 @@ export function parseMermaidToJSON(mermaidCode: string): SystemGraph {
             label: nodeId,
             type: "Unknown",
             shape: "rectangle",
-            layer: "Unknown",
+            layer: "Other Services",
             severity: "Medium",
             subgraphId: currentSubgraphId,
             subgraphTitle: currentSubgraphTitle,
@@ -257,7 +257,7 @@ function inferLayerFromContext(
     return "Frontend";
   if (context.includes("external") || context.includes("auth"))
     return "External";
-  return "Unknown";
+  return "Other Services";
 }
 
 /**

--- a/types/diagram.ts
+++ b/types/diagram.ts
@@ -7,7 +7,7 @@ export type DiagramLayer =
   | "Database"
   | "Infrastructure"
   | "External"
-  | "Unknown";
+  | "Other Services";
 
 /**
  * Represents the criticality of a node based on its dependencies.


### PR DESCRIPTION
## Description

Implemented layer/category filtering toggles for the interactive D3 diagram to help users declutter architecture visualizations by selectively showing or hiding nodes based on their architectural layer.

### Changes Made

* Added a new `LayerToggle` component with layer-based checkboxes.
* Added support for filtering diagram nodes by active layers.
* Filtered links dynamically to ensure only connections between visible nodes are rendered.
* Integrated layer filtering with the existing D3 rendering pipeline.
* Added default active layers in `DiagramContext`.
* Added layer toggle UI alongside the existing search functionality.
* Ensured diagram updates automatically when layer selections change.

## Type of Change

* [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
* [x] ✨ New feature (non-breaking change which adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] 📚 Documentation update
* [ ] 🔧 Configuration change
* [ ] ♻️ Refactoring (no functional changes)
* [x] 🎨 Style/UI changes

## Related Issues

Fixes #268

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have made corresponding changes to the documentation
* [x] I have tested my changes locally
* [x] Any dependent changes have been merged and published
