### PR TITLE
fix: block unverified users from creating sessions before OTP verification

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -80,6 +80,18 @@ export const authOptions: AuthOptions = {
             throw new Error("User not found");
           }
 
+          // Check if email is verified
+          if (!user.isVerified) {
+            apiGatewayErrorsTotal.inc({ status_code: "403" });
+
+            httpRequestDurationSeconds.observe(
+              { route },
+              (Date.now() - startTime) / 1000,
+            );
+
+            throw new Error("Please verify your email before logging in");
+          }
+
           // Rate limit by account (email)
           const accountLimitResult = await loginRateLimitAccount.limit(
             credentials.email,


### PR DESCRIPTION
## Description

Fixed a critical authentication flow issue where users could obtain active authenticated sessions before completing OTP/email verification.

Previously, newly registered users were being authenticated successfully through the NextAuth credentials provider even when `isVerified=false`. This caused inconsistent frontend/backend authentication behavior and allowed unverified users to appear logged in until protected APIs rejected access.

### Changes made:

* Added verification checks inside the NextAuth `authorize()` credentials flow
* Prevented session creation for users with `isVerified=false`
* Added proper error handling for unverified login attempts
* Preserved the existing OTP verification and resend OTP architecture
* Ensured unverified users remain persisted in the database for secure OTP handling and account recovery flows

## Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New feature (non-breaking change which adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] 📚 Documentation update
* [ ] 🔧 Configuration change
* [ ] ♻️ Refactoring (no functional changes)
* [ ] 🎨 Style/UI changes

## Related Issues

Fixes #358 

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have tested my changes locally
* [x] Authentication flow works correctly after OTP verification
* [x] Unverified users can no longer create active sessions

## Additional Notes

This fix improves authentication consistency and security by ensuring verification state and authentication state remain synchronized throughout the signup/login flow.
