### PR TITLE
Fix exhaustive-deps warning in UserDetailsCard

### DIFF
--- a/app/(protected)/profile/components/UserDetailsCard.tsx
+++ b/app/(protected)/profile/components/UserDetailsCard.tsx
@@ -83,7 +83,7 @@ export function UserDetailsCard({
       setIsLoadingFullUser(false);
     };
     fetchUser();
-  }, [session]);
+  }, [session, getUser]);
 
   if (!user) {
     return <UserDetailsCardSkeleton />;

--- a/hooks/useGetUser.ts
+++ b/hooks/useGetUser.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import axios from "axios";
 import { DOC_ROUTES } from "@/lib/routes";
@@ -26,7 +26,7 @@ export function useGetUser() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const getUser = async (): Promise<UserResponse | null> => {
+  const getUser = useCallback(async (): Promise<UserResponse | null> => {
     // @ts-expect-error accessToken is added to session in NextAuth callbacks
     if (!session?.user?.accessToken) {
       setError("No access token available. Please log in.");
@@ -63,7 +63,7 @@ export function useGetUser() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [session]);
 
   return {
     getUser,


### PR DESCRIPTION
## Description

This PR resolves the `react-hooks/exhaustive-deps` warning in `UserDetailsCard` by stabilizing the `getUser` function returned from `useGetUser`.

### Changes Made

- Memoize `getUser` using `useCallback` inside `useGetUser`
- Add `getUser` to the `UserDetailsCard` effect dependency array
- Ensure all effect dependencies are declared correctly
- Preserve existing profile and subscription data loading behavior
- Prevent potential stale closure issues while maintaining stable renders

### Result

- Removes the `react-hooks/exhaustive-deps` warning
- Aligns the implementation with React Hook best practices
- Avoids unnecessary effect executions and re-render loops
- Improves maintainability and future reliability of the profile data fetching flow


## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🎨 Style/UI changes

## Related Issues

Fixes #366

## Screenshots (if applicable)

Not applicable 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [ ] Any dependent changes have been merged and published

## Additional Notes
The warning originated because `getUser` was referenced inside a `useEffect` but omitted from the dependency array. By memoizing the function with `useCallback`, it can now be safely included as a dependency without causing repeated executions.

