### PR TITLE
fix(validation): support modern OpenAI project and service API key formats

### DIFF
--- a/lib/crypto/encryption.ts
+++ b/lib/crypto/encryption.ts
@@ -256,9 +256,9 @@ export function validateApiKeyFormat(
     return /^AI[a-zA-Z0-9_-]{30,}$/.test(apiKey);
   }
 
-  // OpenAI API keys typically start with "sk-" and contain alphanumeric characters
+  // OpenAI API keys typically start with "sk-" and contain alphanumeric characters, hyphens, and underscores
   if (provider === "openai") {
-    return /^sk-[a-zA-Z0-9]{20,}$/.test(apiKey);
+    return /^sk-[a-zA-Z0-9_-]{20,}$/.test(apiKey);
   }
 
   return false;


### PR DESCRIPTION
## Description

Fixes an issue where valid modern OpenAI API keys were incorrectly rejected by format validation.

The existing validation logic only allowed alphanumeric characters after the `sk-` prefix:

```ts
if (provider === "openai") {
  return /^sk-[a-zA-Z0-9]{20,}$/.test(apiKey);
}
```

Modern OpenAI project-scoped (`sk-proj-*`) and service-account keys may contain hyphens (`-`) and underscores (`_`), causing valid credentials to fail validation before they could be saved or used.

This change updates the OpenAI API key validation logic to support modern key formats while preserving existing prefix and minimum-length requirements.


## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🎨 Style/UI changes

## Related Issues
Fixes #387 

## Screenshots (if applicable)
Not applicable 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [x] Any dependent changes have been merged and published

## Additional Notes
The following valid OpenAI keys were rejected:

```text
sk-proj-aBcDeF-GhIjKlMnOpQrStUvWxYz12345
sk-proj_test-Example_12345678901234567890
```

### After

Validation now accepts modern OpenAI key formats that include:

* Hyphens (`-`)
* Underscores (`_`)

while continuing to reject obviously invalid values that do not follow the expected `sk-` prefix format.

No behavior was changed for any other provider.
