### PR TITLE
fix(rate-limit): prevent fallback limiter key collisions and stale memory growth

### DIFF
--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -14,15 +14,25 @@ const redis =
 const inMemoryLimits = new Map<string, { count: number; resetAt: number }>();
 
 function checkInMemoryLimit(
+  prefix: string,
   key: string,
   maxRequests: number,
   windowMs: number,
 ) {
   const now = Date.now();
-  const limit = inMemoryLimits.get(key);
+
+  // Cleanup expired entries
+  for (const [k, value] of inMemoryLimits.entries()) {
+    if (now > value.resetAt) {
+      inMemoryLimits.delete(k);
+    }
+  }
+
+  const fullKey = `${prefix}:${key}`;
+  const limit = inMemoryLimits.get(fullKey);
 
   if (!limit || now > limit.resetAt) {
-    inMemoryLimits.set(key, { count: 1, resetAt: now + windowMs });
+    inMemoryLimits.set(fullKey, { count: 1, resetAt: now + windowMs });
     return {
       success: true,
       limit: maxRequests,
@@ -78,16 +88,20 @@ export const generationRateLimits = redis
     }
   : {
       free: {
-        limit: async (key: string) => checkInMemoryLimit(key, 5, 3600000),
+        limit: async (key: string) =>
+          checkInMemoryLimit("generation:free", key, 5, 3600000),
       } as unknown as Ratelimit,
       guest: {
-        limit: async (key: string) => checkInMemoryLimit(key, 1, 86400000), // 1 per day
+        limit: async (key: string) =>
+          checkInMemoryLimit("generation:guest", key, 1, 86400000), // 1 per day
       } as unknown as Ratelimit,
       pro: {
-        limit: async (key: string) => checkInMemoryLimit(key, 50, 3600000),
+        limit: async (key: string) =>
+          checkInMemoryLimit("generation:pro", key, 50, 3600000),
       } as unknown as Ratelimit,
       enterprise: {
-        limit: async (key: string) => checkInMemoryLimit(key, 200, 3600000),
+        limit: async (key: string) =>
+          checkInMemoryLimit("generation:enterprise", key, 200, 3600000),
       } as unknown as Ratelimit,
     };
 
@@ -98,7 +112,7 @@ export const otpRateLimit = redis
       analytics: true,
     })
   : ({
-      limit: async (key: string) => checkInMemoryLimit(key, 1, 60000),
+      limit: async (key: string) => checkInMemoryLimit("otp", key, 1, 60000),
     } as unknown as Ratelimit);
 
 export const signupRateLimitIP = redis
@@ -108,7 +122,8 @@ export const signupRateLimitIP = redis
       analytics: true,
     })
   : ({
-      limit: async (key: string) => checkInMemoryLimit(key, 3, 3600000),
+      limit: async (key: string) =>
+        checkInMemoryLimit("signup", key, 3, 3600000),
     } as unknown as Ratelimit);
 
 export const loginRateLimitIP = redis
@@ -118,7 +133,8 @@ export const loginRateLimitIP = redis
       analytics: true,
     })
   : ({
-      limit: async (key: string) => checkInMemoryLimit(key, 5, 60000),
+      limit: async (key: string) =>
+        checkInMemoryLimit("login:ip", key, 5, 60000),
     } as unknown as Ratelimit);
 
 export const loginRateLimitAccount = redis
@@ -128,7 +144,8 @@ export const loginRateLimitAccount = redis
       analytics: true,
     })
   : ({
-      limit: async (key: string) => checkInMemoryLimit(key, 5, 3600000),
+      limit: async (key: string) =>
+        checkInMemoryLimit("login:account", key, 5, 3600000),
     } as unknown as Ratelimit);
 
 export const contactRateLimitIP = redis
@@ -138,5 +155,6 @@ export const contactRateLimitIP = redis
       analytics: true,
     })
   : ({
-      limit: async (key: string) => checkInMemoryLimit(key, 3, 3600000),
+      limit: async (key: string) =>
+        checkInMemoryLimit("contact", key, 3, 3600000),
     } as unknown as Ratelimit);


### PR DESCRIPTION
## Description

This PR fixes two issues in the fallback in-memory rate limiter that is used when Redis is unavailable:

1. **Key Collisions** – Different rate limiters were sharing the same in-memory storage keys, allowing unrelated limiters (signup, login, contact, OTP, generation, etc.) to interfere with each other's rate-limit state.
2. **Memory Growth** – Expired rate-limit records were never removed, causing stale entries to accumulate in memory over time.

### Changes Made

* Added limiter-specific key namespacing for in-memory rate-limit records.
* Updated fallback limiter implementations to use unique prefixes.
* Added automatic cleanup of expired entries before processing rate-limit checks.
* Preserved all existing rate-limit thresholds and behavior.
* Left Redis-backed rate limiting completely unchanged.

### Result

* Rate-limit state is isolated per limiter.
* Unrelated endpoints can no longer affect each other's limits.
* Expired records are automatically removed from memory.
* No behavioral changes when Redis is available.


## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🎨 Style/UI changes

## Related Issues
Fixes #389

## Screenshots (if applicable)
Not applicable 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [x] Any dependent changes have been merged and published

## Additional Notes

The fix is intentionally scoped only to the fallback in-memory rate limiter implementation. Redis-based rate limiting behavior, API routes, thresholds, and response formats remain unchanged.
